### PR TITLE
Fix Book cover image - use isbn even when numeric

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -64,10 +64,10 @@ export const Markdown = React.memo(({ children }: MarkdownProps) => {
         </>
       ) : (
         <>
-          {typeof frontmatter?.isbn === "string" ? (
+          {frontmatter?.isbn ? (
             // If the note has an ISBN, show the book cover
             <div className="mb-3 inline-flex">
-              <BookCover isbn={frontmatter.isbn} />
+              <BookCover isbn={`${frontmatter.isbn}`} />
             </div>
           ) : null}
           {typeof frontmatter?.github === "string" ? (


### PR DESCRIPTION
When setting the _isbn_ without `-` (ie. **9781542866507** instead of **978-1542866507**) the yaml formatter take it as a number and the cover image is not set.