### PR TITLE
docs: update `CONTRIBUTING.md` to add missing token scopes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
     gh repo clone lumen-notes/lumen
     ```
 
-1.  Generate a GitHub [personal access token (classic)](https://github.com/settings/tokens/new) with `repo` and `gist` scopes, then add it to a `.env.local` file in the root directory:
+1.  Generate a GitHub [personal access token (classic)](https://github.com/settings/tokens/new) with `repo`, `gist`, and `user:email` scopes, then add it to a `.env.local` file in the root directory:
 
     ```shell
     VITE_GITHUB_PAT=<your token here>


### PR DESCRIPTION
Yup, turns out the token needs `user:email` based on:

https://github.com/lumen-notes/lumen/blob/b66c81ca81aa480bfb45f955bcf4a05fa98d9f1d/src/components/github-auth.tsx#L59