### PR TITLE
fix: shortcuts in windows/chrome

### DIFF
--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -42,7 +42,7 @@ export function NavBar({ position }: { position: "left" | "bottom" }) {
 
   useEvent("keydown", (event: KeyboardEvent) => {
     // Navigate to settings page with `command + ,`
-    if (event.key === "," && event.metaKey) {
+    if (event.key === "," && (event.metaKey || event.ctrlKey)) {
       navigate("/settings")
       event.preventDefault()
     }

--- a/src/components/new-note-dialog.tsx
+++ b/src/components/new-note-dialog.tsx
@@ -104,7 +104,7 @@ function Provider({ children }: { children: React.ReactNode }) {
 
   useEvent("keydown", (event) => {
     // Toggle dialog with `command + i`
-    if (event.key === "i" && event.metaKey && !event.shiftKey && !disabled) {
+    if (event.key === "i" && (event.metaKey || event.ctrlKey) && !event.shiftKey && !disabled) {
       toggle()
       event.preventDefault()
     }

--- a/src/components/note-card-form.tsx
+++ b/src/components/note-card-form.tsx
@@ -147,7 +147,7 @@ export function NoteCardForm({
               }
 
               // Submit on Command + Enter
-              if (event.key === "Enter" && event.metaKey) {
+              if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
                 handleSubmit()
                 event.preventDefault()
               }

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -147,7 +147,7 @@ export const NoteCard = React.memo(function NoteCard({
           }
 
           // Copy markdown with `command + c` if no text is selected
-          if (event.metaKey && event.key == "c" && !window.getSelection()?.toString()) {
+          if ((event.metaKey || event.ctrlKey) && event.key == "c" && !window.getSelection()?.toString()) {
             copy(note?.content || "")
             event.preventDefault()
           }
@@ -159,13 +159,13 @@ export const NoteCard = React.memo(function NoteCard({
           }
 
           // Open dropdown with `command + .`
-          if (event.key === "." && event.metaKey) {
+          if (event.key === "." && (event.metaKey || event.ctrlKey)) {
             setIsDropdownOpen(true)
             event.preventDefault()
           }
 
           // Delete note with `command + backspace`
-          if (event.metaKey && event.key === "Backspace") {
+          if ((event.metaKey || event.ctrlKey) && event.key === "Backspace") {
             handleDeleteNote(id)
             event.preventDefault()
           }

--- a/src/components/panel.tsx
+++ b/src/components/panel.tsx
@@ -70,7 +70,8 @@ export function Panel({
           }
 
           // Focus search input with `command + f`
-          if (event.key === "f" && event.metaKey) {
+          // Note: on windows+chrome a note needs to be in focus. Otherwise it will open Chrome's find-in-page 
+          if (event.key === "f" && (event.metaKey || event.ctrlKey)) {
             const searchInput =
               panelRef.current?.querySelector<HTMLInputElement>("input[type=search]")
             if (searchInput) {
@@ -82,7 +83,7 @@ export function Panel({
           // Focus prev/next note with `command + shift + up/down`
           if (
             (event.key === "ArrowUp" || event.key === "ArrowDown") &&
-            event.metaKey &&
+            (event.metaKey || event.ctrlKey) &&
             event.shiftKey
           ) {
             const noteElements = Array.from(

--- a/src/components/panels.tsx
+++ b/src/components/panels.tsx
@@ -40,7 +40,7 @@ function Root({ children }: React.PropsWithChildren) {
     // Focus prev/next panel with `command + shift + left/right`
     if (
       (event.key === "ArrowLeft" || event.key === "ArrowRight") &&
-      event.metaKey &&
+      (event.metaKey || event.ctrlKey)  &&
       event.shiftKey
     ) {
       const panelElements = Array.from(document.querySelectorAll<HTMLElement>("[data-panel]"))


### PR DESCRIPTION
Fixes #242 

Added `event.ctrlKey` in most conditions to make it work on windows. Tested it and works great 👍 

Although I didn't do it to `ctrl + shift + c` because it kept opening the developer console in chrome
