### PR TITLE
Feat: Expanding on command-menu

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -4,12 +4,12 @@ import { useAtomValue } from "jotai"
 import qs from "qs"
 import React from "react"
 import { flushSync } from "react-dom"
-import { useNavigate } from "react-router-dom"
 import { useEvent } from "react-use"
 import { Card } from "../components/card"
 import { usePanelActions, usePanels } from "../components/panels"
 import { tagSearcherAtom } from "../global-state"
 import { useDebouncedValue } from "../hooks/debounced-value"
+import { useNavigateWithCache } from "../hooks/navigate-with-cache"
 import { useSaveNote } from "../hooks/note"
 import { useSearchNotes } from "../hooks/search"
 import { templateSchema } from "../schema"
@@ -32,8 +32,7 @@ export function CommandMenu() {
   const saveNote = useSaveNote()
   const panels = usePanels()
   const { openPanel } = usePanelActions()
-  const routerNavigate = useNavigate()
-  // const navigate = useNavigateWithCache()
+  const routerNavigate = useNavigateWithCache()
 
   // Refs
   const prevActiveElement = React.useRef<HTMLElement>()
@@ -58,13 +57,10 @@ export function CommandMenu() {
   }, [])
 
   const navigate = React.useCallback(
-    (url: string, toPage?: boolean) => {
-      if (openPanel && !toPage) {
+    (url: string, { openInPanel = true }: { openInPanel?: boolean } = {}) => {
+      if (openInPanel && openPanel) {
         // If we're in a panels context, navigate by opening a panel
         openPanel(url, panels.length - 1)
-        // } else if (isFullscreen) {
-        //   // If we're in fullscreen mode, add `fullscreen=true` to the query string
-        //   routerNavigate(url.includes("?") ? `${url}&fullscreen=true` : `${url}?fullscreen=true`)
       } else {
         // Otherwise, navigate using the router
         routerNavigate(url)
@@ -234,23 +230,31 @@ export function CommandMenu() {
             </Command.Group>
           ) : (
             <Command.Group heading="Jump to">
-              <CommandItem key={"Notes"} icon={<NoteIcon16 />} onSelect={() => navigate(`/`)}>
+              <CommandItem
+                key="Notes"
+                icon={<NoteIcon16 />}
+                onSelect={() => navigate(`/`, { openInPanel: false })}
+              >
                 Notes
               </CommandItem>
-              <CommandItem key={"Tags"} icon={<TagIcon16 />} onSelect={() => navigate(`/tags`)}>
-                Tags
+              <CommandItem
+                key="Today"
+                icon={<CalendarIcon16 date={new Date().getDate()} />}
+                onSelect={() => navigate(`/${toDateString(new Date())}`, { openInPanel: false })}
+              >
+                Today
               </CommandItem>
               <CommandItem
-                key={"Calendar"}
-                icon={<CalendarIcon16 />}
-                onSelect={() => navigate(`/${toDateString(new Date())}`)}
+                key="Tags"
+                icon={<TagIcon16 />}
+                onSelect={() => navigate(`/tags`, { openInPanel: false })}
               >
-                Calendar
+                Tags
               </CommandItem>
               <CommandItem
                 key={"Settings"}
                 icon={<SettingsIcon16 />}
-                onSelect={() => navigate("/settings", true)}
+                onSelect={() => navigate("/settings", { openInPanel: false })}
               >
                 Settings
               </CommandItem>

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -13,10 +13,17 @@ import { useDebouncedValue } from "../hooks/debounced-value"
 import { useSaveNote } from "../hooks/note"
 import { useSearchNotes } from "../hooks/search"
 import { templateSchema } from "../schema"
-import { formatDate, formatDateDistance } from "../utils/date"
+import { formatDate, formatDateDistance, toDateString } from "../utils/date"
 import { pluralize } from "../utils/pluralize"
 import { removeParentTags } from "../utils/remove-parent-tags"
-import { CalendarIcon16, PlusIcon16, SearchIcon16, TagIcon16 } from "./icons"
+import {
+  CalendarIcon16,
+  NoteIcon16,
+  PlusIcon16,
+  SearchIcon16,
+  SettingsIcon16,
+  TagIcon16,
+} from "./icons"
 import { NoteFavicon } from "./note-favicon"
 
 export function CommandMenu() {
@@ -26,6 +33,7 @@ export function CommandMenu() {
   const panels = usePanels()
   const { openPanel } = usePanelActions()
   const routerNavigate = useNavigate()
+  // const navigate = useNavigateWithCache()
 
   // Refs
   const prevActiveElement = React.useRef<HTMLElement>()
@@ -50,8 +58,8 @@ export function CommandMenu() {
   }, [])
 
   const navigate = React.useCallback(
-    (url: string) => {
-      if (openPanel) {
+    (url: string, toPage?: boolean) => {
+      if (openPanel && !toPage) {
         // If we're in a panels context, navigate by opening a panel
         openPanel(url, panels.length - 1)
         // } else if (isFullscreen) {
@@ -224,7 +232,30 @@ export function CommandMenu() {
                 Create new note "{debouncedQuery}"
               </CommandItem>
             </Command.Group>
-          ) : null}
+          ) : (
+            <Command.Group heading="Jump to">
+              <CommandItem key={"Notes"} icon={<NoteIcon16 />} onSelect={() => navigate(`/`)}>
+                Notes
+              </CommandItem>
+              <CommandItem key={"Tags"} icon={<TagIcon16 />} onSelect={() => navigate(`/tags`)}>
+                Tags
+              </CommandItem>
+              <CommandItem
+                key={"Calendar"}
+                icon={<CalendarIcon16 />}
+                onSelect={() => navigate(`/${toDateString(new Date())}`)}
+              >
+                Calendar
+              </CommandItem>
+              <CommandItem
+                key={"Settings"}
+                icon={<SettingsIcon16 />}
+                onSelect={() => navigate("/settings", true)}
+              >
+                Settings
+              </CommandItem>
+            </Command.Group>
+          )}
         </Command.List>
       </Card>
     </Command.Dialog>

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,21 +1,12 @@
 import { TooltipContentProps } from "@radix-ui/react-tooltip"
 import { useAtomValue, useSetAtom } from "jotai"
 import { selectAtom } from "jotai/utils"
-import React from "react"
-import {
-  NavLinkProps,
-  NavLink as RouterNavLink,
-  resolvePath,
-  useLocation,
-  useMatch,
-  useNavigate,
-  useResolvedPath,
-} from "react-router-dom"
+import { NavLinkProps, NavLink as RouterNavLink, useMatch, useResolvedPath } from "react-router-dom"
 import { useEvent, useNetworkState } from "react-use"
 import { globalStateMachineAtom } from "../global-state"
+import { useNavigateWithCache } from "../hooks/navigate-with-cache"
 import { cx } from "../utils/cx"
 import { toDateString } from "../utils/date"
-import { getPrevPathParams } from "../utils/prev-path-params"
 import { DropdownMenu } from "./dropdown-menu"
 import { useSignOut } from "./github-auth"
 import { IconButton } from "./icon-button"
@@ -174,33 +165,6 @@ function NavLink({
       </Tooltip.Trigger>
       <Tooltip.Content side={tooltipSide}>{props["aria-label"]}</Tooltip.Content>
     </Tooltip>
-  )
-}
-
-function useNavigateWithCache() {
-  const navigate = useNavigate()
-  const location = useLocation()
-
-  return React.useCallback(
-    (to: string) => {
-      const { pathname } = resolvePath(to)
-
-      const prevPathParams = getPrevPathParams(pathname)
-
-      // Clicking the nav link for the current page resets the params for that pages
-      if (location.pathname === pathname) {
-        navigate(to)
-        return
-      }
-
-      if (prevPathParams) {
-        // Navigate to the new path with the previous params for that path
-        navigate({ pathname, search: prevPathParams })
-      } else {
-        navigate(to)
-      }
-    },
-    [navigate, location],
   )
 }
 

--- a/src/hooks/navigate-with-cache.ts
+++ b/src/hooks/navigate-with-cache.ts
@@ -1,0 +1,30 @@
+import React from "react"
+import { useNavigate, useLocation, resolvePath } from "react-router-dom"
+import { getPrevPathParams } from "../utils/prev-path-params"
+
+export function useNavigateWithCache() {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  return React.useCallback(
+    (to: string) => {
+      const { pathname } = resolvePath(to)
+
+      const prevPathParams = getPrevPathParams(pathname)
+
+      // Navigating to the current page resets the params for that pages
+      if (location.pathname === pathname) {
+        navigate(to)
+        return
+      }
+
+      if (prevPathParams) {
+        // Navigate to the new path with the previous params for that path
+        navigate({ pathname, search: prevPathParams })
+      } else {
+        navigate(to)
+      }
+    },
+    [navigate, location],
+  )
+}


### PR DESCRIPTION
Part of #204 

Now the command menu looks like this 👇 (when nothing is typed):

![image](https://github.com/lumen-notes/lumen/assets/46135573/bfda3d09-c9d6-485a-9d98-628b628b2220)


Although I was gonna add a separator line between "Settings" and the rest but realized the only UI separator we have is for the DropdownMenu. 

I might create a separator component soon. @colebemis Should I make a custom one or install `@radix-ui/react-separator` and use that instead ? 