### PR TITLE
Bug fix for create repository

### DIFF
--- a/src/components/repo-form.tsx
+++ b/src/components/repo-form.tsx
@@ -118,6 +118,7 @@ export function RepoForm({ onSubmit, onCancel }: RepoFormProps) {
           value={repoType}
           onValueChange={(value) => setRepoType(value as "new" | "existing")}
           className="flex flex-col gap-3 coarse:gap-4"
+          name="repo-type"
         >
           <div className="flex items-center gap-2">
             <RadioGroup.Item id="repo-new" value="new" />


### PR DESCRIPTION

Fix for #253.

The radio group in `repo-form.tsx` was missing the radio group name. This resulted in only selectExistingRepo function to be called while trying to create a new repo.

Adding the group name `repo-type` fixes the issue. 