### PR TITLE
feat: add ability to filter by open tasks

### DIFF
--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -22,6 +22,7 @@ Search your notes with Lumen's [GitHub-style](https://docs.github.com/en/search-
 | `links`     | `links:>1` matches notes with more than one link.                                                                                          |
 | `backlink`  | `backlink:1652342106359` matches notes that are linked to by the note with ID `1652342106359`.                                             |
 | `backlinks` | `backlinks:>1` matches notes with more than one backlink.                                                                                  |
+| `tasks`     | `tasks:>0` matches notes with at least one open task                                                                                       |
 | `no`        | `no:tag` matches notes without a tag. `no` can be used with any qualifier key or frontmatter key.                                          |
 | `has`       | `has:tag` matches notes with one or more tag. `has` can be used with any qualifier key or frontmatter key. `has` and `-no` are equivalent. |
 

--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -22,7 +22,7 @@ Search your notes with Lumen's [GitHub-style](https://docs.github.com/en/search-
 | `links`     | `links:>1` matches notes with more than one link.                                                                                          |
 | `backlink`  | `backlink:1652342106359` matches notes that are linked to by the note with ID `1652342106359`.                                             |
 | `backlinks` | `backlinks:>1` matches notes with more than one backlink.                                                                                  |
-| `tasks`     | `tasks:>0` matches notes with at least one open task                                                                                       |
+| `tasks`     | `tasks:>0` matches notes with at least one open task.                                                                                      |
 | `no`        | `no:tag` matches notes without a tag. `no` can be used with any qualifier key or frontmatter key.                                          |
 | `has`       | `has:tag` matches notes with one or more tag. `has` can be used with any qualifier key or frontmatter key. `has` and `-no` are equivalent. |
 

--- a/src/hooks/search.ts
+++ b/src/hooks/search.ts
@@ -163,6 +163,10 @@ export function testQualifiers(qualifiers: Qualifier[], item: Note) {
         value = qualifier.values.some((value) => isInRange(item.backlinks.length, value))
         break
 
+      case "tasks":
+        value = qualifier.values.some((value) => isInRange(item.openTasks, value))
+        break
+
       case "no":
         // Match if the item doesn't have the specified property
         value = qualifier.values.some((value) => {
@@ -170,6 +174,8 @@ export function testQualifiers(qualifiers: Qualifier[], item: Note) {
             case "backlinks":
               if (!("backlinks" in item)) return true
               return item.backlinks.length === 0
+            case "tasks":
+              return item.openTasks === 0
             case "tag":
             case "tags":
               return item.tags.length === 0
@@ -201,6 +207,9 @@ export function testQualifiers(qualifiers: Qualifier[], item: Note) {
             case "link":
             case "links":
               return item.links.length === 0
+            case "task":
+            case "tasks":
+              return item.openTasks === 0
             default:
               return !(value in frontmatter)
           }

--- a/src/hooks/search.ts
+++ b/src/hooks/search.ts
@@ -207,7 +207,6 @@ export function testQualifiers(qualifiers: Qualifier[], item: Note) {
             case "link":
             case "links":
               return item.links.length === 0
-            case "task":
             case "tasks":
               return item.openTasks === 0
             default:

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -25,6 +25,8 @@ export type Note = {
 
   /** The ids of all notes that link to this note */
   backlinks: NoteId[]
+  /** How many open tasks (`- [ ]`) the note has */
+  openTasks: number
 }
 
 export type GitHubRepository = {

--- a/src/utils/parse-note.ts
+++ b/src/utils/parse-note.ts
@@ -24,6 +24,7 @@ export const parseNote = memoize((id: NoteId, content: string) => {
   const tags = new Set<string>()
   const dates = new Set<string>()
   const links = new Set<NoteId>()
+  let openTasks = 0
 
   const { frontmatter } = parseFrontmatter(content)
 
@@ -82,6 +83,13 @@ export const parseNote = memoize((id: NoteId, content: string) => {
         })
         break
       }
+
+      case "listItem": {
+        if (node.checked === false) {
+          openTasks++
+        }
+        break
+      }
     }
   })
 
@@ -133,5 +141,6 @@ export const parseNote = memoize((id: NoteId, content: string) => {
     dates: Array.from(dates),
     links: Array.from(links),
     tags: Array.from(tags),
+    openTasks,
   }
 })


### PR DESCRIPTION
This adds `tasks:$qualifier` and `has:tasks` to the query language.

## References
- closes https://github.com/lumen-notes/lumen/issues/286