### PR TITLE
Fix rendering issue with single dollar signs

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -168,7 +168,7 @@ function MarkdownContent({ children, className }: { children: string; className?
         remarkWikilink,
         remarkEmbed,
         remarkTag,
-        remarkMath,
+        [remarkMath, { singleDollarTextMath: false }],
       ]}
       rehypePlugins={[rehypeKatex]}
       remarkRehypeOptions={{


### PR DESCRIPTION
Closes #309

This pull request addresses the issue of single dollar signs causing rendering problems in markdown content within the `src/components/markdown.tsx` file. The solution implemented involves modifying the `remarkPlugins` array to include configuration options for the `remarkMath` plugin. Specifically, the `singleDollarTextMath` option is set to `false`, which prevents single dollar signs from being interpreted as math expressions. This change ensures that text containing single dollar signs is rendered correctly without being mistakenly formatted as mathematical notation. The modification is made directly in the `remarkPlugins` array where the `remarkMath` plugin is initialized, ensuring that the configuration applies to all instances of markdown rendering within the component.

## Before

<img width="148" alt="image" src="https://github.com/lumen-notes/lumen/assets/4608155/ef7dde28-2ec2-4656-aa07-0db7f57ce6f8">


## After

<img width="305" alt="image" src="https://github.com/lumen-notes/lumen/assets/4608155/626d9b7b-57a9-412a-b223-89572af8fdad">


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lumen-notes/lumen/issues/309?shareId=b9d86d37-989c-4fa8-a8e6-82fd84cfafc6).