### PR TITLE
Add robots.txt to disallow all web crawlers

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This pull request introduces a new `robots.txt` file in the `public` directory of the project. The content of this file is designed to disallow all web crawlers from accessing the site, as indicated by the rules specified within the file. The rules are set to apply to all user agents, effectively blocking all bots from indexing or crawling any part of the site. This change is crucial for controlling the site's visibility on the internet and managing how search engines interact with it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lumen-notes/lumen?shareId=b0cca3a0-fcf7-4261-b843-342bd4c86abe).