### PR TITLE
Make pin icon in dropdown menu orange when note is pinned

### DIFF
--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -386,7 +386,7 @@ const _NoteCard = React.memo(function NoteCard({
                 </DropdownMenu.Item>
                 <DropdownMenu.Separator />
                 <DropdownMenu.Item
-                  icon={isPinned(note) ? <PinFillIcon16 className="text-[var(--orange-11)]" /> : <PinIcon16 />}
+                  icon={<PinIcon16 />}
                   onSelect={() => {
                     handleSave({ id, content: togglePin(note.content) })
                   }}

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -386,7 +386,7 @@ const _NoteCard = React.memo(function NoteCard({
                 </DropdownMenu.Item>
                 <DropdownMenu.Separator />
                 <DropdownMenu.Item
-                  icon={isPinned(note) ? <PinFillIcon16 /> : <PinIcon16 />}
+                  icon={isPinned(note) ? <PinFillIcon16 className="text-[var(--orange-11)]" /> : <PinIcon16 />}
                   onSelect={() => {
                     handleSave({ id, content: togglePin(note.content) })
                   }}

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -386,7 +386,7 @@ const _NoteCard = React.memo(function NoteCard({
                 </DropdownMenu.Item>
                 <DropdownMenu.Separator />
                 <DropdownMenu.Item
-                  icon={<PinIcon16 />}
+                  icon={isPinned(note) ? <PinFillIcon16 className="text-[var(--orange-11)]" /> : <PinIcon16 />}
                   onSelect={() => {
                     handleSave({ id, content: togglePin(note.content) })
                   }}


### PR DESCRIPTION
Updates the pin icon in the note card dropdown menu to turn orange when the note is pinned, ensuring visual consistency with the pin icon displayed on the note card itself.

- Adds conditional styling to the `PinFillIcon16` component within the `DropdownMenu.Item` in `src/components/note-card.tsx`. This change applies the same orange color (`var(--orange-11)`) used for the pin icon on the note card when the note is pinned.
- Utilizes the `isPinned` utility function to determine the pin status of a note and conditionally render the styled pin icon accordingly.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lumen-notes/lumen?shareId=f3522397-b0da-4d87-b836-8ca885d71485).