### PR TITLE
Add 'This week' item to command menu

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -12,7 +12,7 @@ import { useNavigateWithCache } from "../hooks/navigate-with-cache"
 import { useSaveNote } from "../hooks/note"
 import { useSearchNotes } from "../hooks/search"
 import { Note, templateSchema } from "../schema"
-import { formatDate, formatDateDistance, toDateString } from "../utils/date"
+import { formatDate, formatDateDistance, toDateString, toWeekString } from "../utils/date"
 import { isPinned } from "../utils/pin"
 import { pluralize } from "../utils/pluralize"
 import { removeParentTags } from "../utils/remove-parent-tags"
@@ -27,6 +27,7 @@ import {
 } from "./icons"
 import { NoteFavicon } from "./note-favicon"
 import { usePanelActions, usePanels } from "./panels"
+import { getISOWeek } from "date-fns"
 
 export function CommandMenu() {
   const searchNotes = useSearchNotes()
@@ -224,6 +225,13 @@ export function CommandMenu() {
                   onSelect={() => navigate(`/${toDateString(new Date())}`, { openInPanel: false })}
                 >
                   Today
+                </CommandItem>
+                <CommandItem
+                  key="This week"
+                  icon={<CalendarIcon16 number={getISOWeek(new Date())} />}
+                  onSelect={() => navigate(`/${toWeekString(new Date())}`, { openInPanel: false })}
+                >
+                  This week
                 </CommandItem>
                 <CommandItem
                   key="Tags"

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -27,7 +27,6 @@ import {
 } from "./icons"
 import { NoteFavicon } from "./note-favicon"
 import { usePanelActions, usePanels } from "./panels"
-import { getISOWeek } from "date-fns"
 
 export function CommandMenu() {
   const searchNotes = useSearchNotes()
@@ -145,7 +144,7 @@ export function CommandMenu() {
             <Command.Group heading="Date">
               <CommandItem
                 key={dateString}
-                icon={<CalendarIcon16 number={new Date(dateString).getUTCDate()} />}
+                icon={<CalendarIcon16>{new Date(dateString).getUTCDate()}</CalendarIcon16>}
                 description={formatDateDistance(dateString)}
                 onSelect={() => navigate(`/${dateString}`)}
               >
@@ -221,14 +220,14 @@ export function CommandMenu() {
                 </CommandItem>
                 <CommandItem
                   key="Today"
-                  icon={<CalendarIcon16 number={new Date().getDate()} />}
+                  icon={<CalendarIcon16>{new Date().getDate()}</CalendarIcon16>}
                   onSelect={() => navigate(`/${toDateString(new Date())}`, { openInPanel: false })}
                 >
                   Today
                 </CommandItem>
                 <CommandItem
                   key="This week"
-                  icon={<CalendarIcon16 number={getISOWeek(new Date())} />}
+                  icon={<CalendarIcon16>W</CalendarIcon16>}
                   onSelect={() => navigate(`/${toWeekString(new Date())}`, { openInPanel: false })}
                 >
                   This week

--- a/src/components/icons.stories.tsx
+++ b/src/components/icons.stories.tsx
@@ -40,26 +40,26 @@ export const All = {
   ),
 }
 
-export const Calendar: StoryObj<{ size: "16" | "24"; number: number }> = {
+export const Calendar: StoryObj<{ size: "16" | "24"; children: string }> = {
   render: (args) => {
     switch (args.size) {
       case "16":
-        return <icons.CalendarIcon16 number={args.number} />
+        return <icons.CalendarIcon16>{args.children}</icons.CalendarIcon16>
       case "24":
-        return <icons.CalendarIcon24 number={args.number} />
+        return <icons.CalendarIcon24>{args.children}</icons.CalendarIcon24>
     }
   },
   args: {
     size: "16",
-    number: 1,
+    children: "1",
   },
   argTypes: {
     size: {
       options: ["16", "24"],
       control: { type: "radio" },
     },
-    number: {
-      control: { type: "number" },
+    children: {
+      control: { type: "text" },
     },
   },
   parameters: {

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -118,7 +118,7 @@ export function TagIcon16(props: IconProps) {
   )
 }
 
-export function CalendarIcon24({ number }: IconProps & { number?: number }) {
+export function CalendarIcon24({ children }: IconProps & { children?: number | string }) {
   return (
     <Icon size={24}>
       <path
@@ -133,13 +133,16 @@ export function CalendarIcon24({ number }: IconProps & { number?: number }) {
         fontSize="10px"
         className="font-mono font-semibold leading-none"
       >
-        {number}
+        {children}
       </text>
     </Icon>
   )
 }
 
-export function CalendarFillIcon24({ number, ...props }: IconProps & { number?: number }) {
+export function CalendarFillIcon24({
+  children,
+  ...props
+}: IconProps & { children?: number | string }) {
   return (
     <Icon size={24} {...props}>
       <path
@@ -155,13 +158,13 @@ export function CalendarFillIcon24({ number, ...props }: IconProps & { number?: 
         fill="currentColor"
         className="font-mono font-semibold leading-none text-bg-inset"
       >
-        {number}
+        {children}
       </text>
     </Icon>
   )
 }
 
-export function CalendarIcon16({ number, ...props }: IconProps & { number?: number }) {
+export function CalendarIcon16({ children, ...props }: IconProps & { children?: number | string }) {
   return (
     <Icon size={16} {...props}>
       <path d="M13 4H3v1.5h10V4Z" />
@@ -178,7 +181,7 @@ export function CalendarIcon16({ number, ...props }: IconProps & { number?: numb
         fill="currentColor"
         className="font-mono font-bold leading-none"
       >
-        {number}
+        {children}
       </text>
     </Icon>
   )

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -67,9 +67,9 @@ export function NavBar({ position }: { position: "left" | "bottom" }) {
           >
             {({ isActive }) =>
               isActive ? (
-                <CalendarFillIcon24 number={new Date().getDate()} />
+                <CalendarFillIcon24>{new Date().getDate()}</CalendarFillIcon24>
               ) : (
-                <CalendarIcon24 number={new Date().getDate()} />
+                <CalendarIcon24>{new Date().getDate()}</CalendarIcon24>
               )
             }
           </NavLink>

--- a/src/components/note-favicon.tsx
+++ b/src/components/note-favicon.tsx
@@ -23,12 +23,14 @@ export function NoteFavicon({
 
   // Daily note
   if (isValidDateString(note.id)) {
-    icon = <CalendarIcon16 data-testid="favicon-daily" number={new Date(note.id).getUTCDate()} />
+    icon = (
+      <CalendarIcon16 data-testid="favicon-daily">{new Date(note.id).getUTCDate()}</CalendarIcon16>
+    )
   }
 
   // Weekly note
   if (isValidWeekString(note.id)) {
-    icon = <CalendarIcon16 data-testid="favicon-weekly" number={Number(note.id.split("-W")[1])} />
+    icon = <CalendarIcon16 data-testid="favicon-weekly">W</CalendarIcon16>
   }
 
   // GitHub

--- a/src/panels/daily.tsx
+++ b/src/panels/daily.tsx
@@ -30,7 +30,7 @@ export function DailyPanel({ id, params = {}, onClose }: PanelProps) {
       key={date}
       title={formatDate(date)}
       description={formatDateDistance(date)}
-      icon={<CalendarIcon16 number={new Date(date).getUTCDate()} />}
+      icon={<CalendarIcon16>{new Date(date).getUTCDate()}</CalendarIcon16>}
       onClose={onClose}
     >
       <div className="flex flex-col">

--- a/src/panels/weekly.tsx
+++ b/src/panels/weekly.tsx
@@ -39,7 +39,7 @@ export function WeeklyPanel({ id, params = {}, onClose }: PanelProps) {
       key={week}
       title={formatWeek(week)}
       description={formatWeekDistance(week)}
-      icon={<CalendarIcon16 number={Number(week.split("-W")[1])} />}
+      icon={<CalendarIcon16>W</CalendarIcon16>}
       onClose={onClose}
     >
       <div className="flex flex-col">


### PR DESCRIPTION
Adds a "This week" item to the "Jump to" section of the command menu in `src/components/command-menu.tsx`, enabling users to navigate to the current weekly note.

- **Navigation Enhancement**: Introduces a new `CommandItem` for "This week" in the command menu, utilizing `toWeekString(new Date())` to generate the current week string and `navigate` function for redirection.
- **Calendar Icon Update**: Implements the use of `getISOWeek` from `date-fns` to display the current week number on the calendar icon for the "This week" menu item.
- **Code Integration**: Adds the import statement for `getISOWeek` from `date-fns` to support the week number calculation.
