### PR TITLE
Add 'Revert changes' button to note card

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -658,6 +658,15 @@ export function PinFillIcon12(props: IconProps) {
     </Icon>
   )
 }
+
+export function UndoIcon16(props: IconProps) {
+  return (
+    <Icon size={16} {...props}>
+      <path d="m3.31 5 2.75-2.75L5 1.19.44 5.75 5 10.31l1.06-1.06L3.31 6.5h7.19a3 3 0 1 1 0 6H9V14h1.5a4.5 4.5 0 1 0 0-9H3.31Z" />
+    </Icon>
+  )
+}
+
 // Brand icons
 
 export function GitHubIcon16() {

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -386,9 +386,12 @@ const _NoteCard = React.memo(function NoteCard({
               </DropdownMenu.Trigger>
               <DropdownMenu.Content align="end">
                 {isDirty ? (
-                  <DropdownMenu.Item icon={<UndoIcon16 />} onSelect={discardChanges}>
-                    Discard changes
-                  </DropdownMenu.Item>
+                  <>
+                    <DropdownMenu.Item icon={<UndoIcon16 />} onSelect={discardChanges}>
+                      Discard changes
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator />
+                  </>
                 ) : null}
                 <DropdownMenu.Item
                   icon={

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -30,6 +30,7 @@ import {
   PinIcon16,
   ShareIcon16,
   TrashIcon16,
+  UndoIcon16,
 } from "./icons"
 import { Link } from "./link"
 import { Markdown } from "./markdown"
@@ -384,14 +385,11 @@ const _NoteCard = React.memo(function NoteCard({
                 </IconButton>
               </DropdownMenu.Trigger>
               <DropdownMenu.Content align="end">
-               {isDirty ? (
-                 <DropdownMenu.Item
-                    icon={<ExternalLinkIcon16 />}
-                    onSelect={discardChanges}
-                  >
+                {isDirty ? (
+                  <DropdownMenu.Item icon={<UndoIcon16 />} onSelect={discardChanges}>
                     Discard changes
                   </DropdownMenu.Item>
-               ) : null}
+                ) : null}
                 <DropdownMenu.Item
                   icon={
                     isPinned(note) ? (

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -208,7 +208,7 @@ const _NoteCard = React.memo(function NoteCard({
     return editorValue !== note.content
   }, [note, editorValue, defaultValue])
 
-  const revertChanges = React.useCallback(() => {
+  const discardChanges = React.useCallback(() => {
     // Reset editor value to the last saved state of the note
     setEditorValue(note?.content ?? defaultValue)
     // Clear the "draft" from localStorage
@@ -387,9 +387,9 @@ const _NoteCard = React.memo(function NoteCard({
                {isDirty ? (
                  <DropdownMenu.Item
                     icon={<ExternalLinkIcon16 />}
-                    onSelect={revertChanges}
+                    onSelect={discardChanges}
                   >
-                    Revert changes
+                    Discard changes
                   </DropdownMenu.Item>
                ) : null}
                 <DropdownMenu.Item

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -208,6 +208,13 @@ const _NoteCard = React.memo(function NoteCard({
     return editorValue !== note.content
   }, [note, editorValue, defaultValue])
 
+  const revertChanges = React.useCallback(() => {
+    // Reset editor value to the last saved state of the note
+    setEditorValue(note?.content ?? defaultValue)
+    // Clear the "draft" from localStorage
+    localStorage.removeItem(getStorageKey({ githubRepo, id }))
+  }, [note, defaultValue, githubRepo, id])
+
   return (
     <Card
       // Used for focus management
@@ -377,6 +384,14 @@ const _NoteCard = React.memo(function NoteCard({
                 </IconButton>
               </DropdownMenu.Trigger>
               <DropdownMenu.Content align="end">
+               {isDirty ? (
+                 <DropdownMenu.Item
+                    icon={<ExternalLinkIcon16 />}
+                    onSelect={revertChanges}
+                  >
+                    Revert changes
+                  </DropdownMenu.Item>
+               ) : null}
                 <DropdownMenu.Item
                   icon={
                     isPinned(note) ? (


### PR DESCRIPTION
Closes #349

Adds a "Revert changes" option to the note card dropdown menu for reverting edits made to a note in the editor.

- Implements the `revertChanges` function to reset the editor content to the last saved state of the note and clear the "draft" from localStorage.
- Adds a conditional rendering for the "Revert changes" dropdown item, which only appears when the editor state is dirty.
- Utilizes the existing `isDirty` state to determine if the editor content has been modified from the last saved state, enabling the "Revert changes" option accordingly.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lumen-notes/lumen/issues/349?shareId=38e68fd7-c894-4d4c-b346-33183e75d754).