### PR TITLE
Display emoji as favicon for notes starting with an emoji

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "date-fns": "^2.29.2",
         "date-fns-tz": "^1.3.7",
         "ejs": "^3.1.10",
+        "emoji-regex": "^10.3.0",
         "express": "^4.19.2",
         "fast-fuzzy": "^1.11.2",
         "fast-memoize": "^2.5.2",
@@ -2634,6 +2635,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
@@ -16032,10 +16039,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
     },
     "node_modules/emojilib": {
       "version": "2.4.0",
@@ -17188,6 +17194,12 @@
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.34.1",
@@ -51958,6 +51970,12 @@
           "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
           "dev": true
         },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
         "string-width": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -61429,10 +61447,9 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
     },
     "emojilib": {
       "version": "2.4.0",
@@ -62203,6 +62220,14 @@
         "language-tags": "^1.0.5",
         "minimatch": "^3.1.2",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "date-fns": "^2.29.2",
     "date-fns-tz": "^1.3.7",
     "ejs": "^3.1.10",
+    "emoji-regex": "^10.3.0",
     "express": "^4.19.2",
     "fast-fuzzy": "^1.11.2",
     "fast-memoize": "^2.5.2",

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -13,6 +13,7 @@ import { useSaveNote } from "../hooks/note"
 import { useSearchNotes } from "../hooks/search"
 import { Note, templateSchema } from "../schema"
 import { formatDate, formatDateDistance, toDateString, toWeekString } from "../utils/date"
+import { removeLeadingEmoji } from "../utils/emoji"
 import { isPinned } from "../utils/pin"
 import { pluralize } from "../utils/pluralize"
 import { removeParentTags } from "../utils/remove-parent-tags"
@@ -296,7 +297,7 @@ function NoteItem({ note, onSelect }: { note: Note; onSelect: () => void }) {
         {parsedTemplate.success ? (
           <span>{parsedTemplate.data.name} template</span>
         ) : (
-          <span>{note.title || note.id}</span>
+          <span>{removeLeadingEmoji(note.title) || note.id}</span>
         )}
         <span className="text-text-secondary">
           {removeParentTags(note.tags)

--- a/src/components/note-editor.tsx
+++ b/src/components/note-editor.tsx
@@ -23,6 +23,7 @@ import { useSaveNote } from "../hooks/note"
 import { useStableSearchNotes } from "../hooks/search"
 import { formatDate, formatDateDistance, isValidUnixTimestamp } from "../utils/date"
 import { getEditorSettings } from "../utils/editor-settings"
+import { removeLeadingEmoji } from "../utils/emoji"
 import { parseFrontmatter } from "../utils/parse-frontmatter"
 import { removeParentTags } from "../utils/remove-parent-tags"
 import { useInsertTemplate } from "./insert-template"
@@ -436,7 +437,9 @@ function useNoteCompletion() {
           info: content,
           apply: (view, completion, from, to) => {
             // Insert link to note
-            const text = `[[${note.id}${note?.title ? `|${note.title}` : ""}]]`
+            const text = `[[${note.id}${
+              note?.title ? `|${removeLeadingEmoji(note.title).trim()}` : ""
+            }]]`
 
             const hasClosingBrackets = view.state.sliceDoc(to, to + 2) === "]]"
             view.dispatch({

--- a/src/components/note-favicon.tsx
+++ b/src/components/note-favicon.tsx
@@ -2,10 +2,10 @@ import { useNetworkState } from "react-use"
 import { Note, templateSchema } from "../schema"
 import { cx } from "../utils/cx"
 import { isValidDateString, isValidWeekString } from "../utils/date"
+import { getLeadingEmoji } from "../utils/emoji"
 import { GitHubAvatar } from "./github-avatar"
 import { CalendarIcon16, NoteIcon16, NoteTemplateIcon16 } from "./icons"
 import { WebsiteFavicon } from "./website-favicon"
-import emojiRegex from "emoji-regex"
 
 type NoteFaviconProps = React.ComponentPropsWithoutRef<"span"> & {
   note: Note
@@ -22,10 +22,16 @@ export function NoteFavicon({
 
   let icon = defaultFavicon
 
-  // Check if note title starts with a single emoji
-  const emojiMatch = note.title.match(emojiRegex())
-  if (emojiMatch && emojiMatch.index === 0) {
-    icon = emojiMatch[0]
+  // Emoji
+  const leadingEmoji = getLeadingEmoji(note.title)
+  if (leadingEmoji) {
+    icon = (
+      <svg className="h-4 w-4" viewBox="0 0 16 16">
+        <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize={16}>
+          {leadingEmoji}
+        </text>
+      </svg>
+    )
   }
 
   // Daily note

--- a/src/components/note-favicon.tsx
+++ b/src/components/note-favicon.tsx
@@ -5,6 +5,7 @@ import { isValidDateString, isValidWeekString } from "../utils/date"
 import { GitHubAvatar } from "./github-avatar"
 import { CalendarIcon16, NoteIcon16, NoteTemplateIcon16 } from "./icons"
 import { WebsiteFavicon } from "./website-favicon"
+import emojiRegex from "emoji-regex"
 
 type NoteFaviconProps = React.ComponentPropsWithoutRef<"span"> & {
   note: Note
@@ -20,6 +21,12 @@ export function NoteFavicon({
   const { online } = useNetworkState()
 
   let icon = defaultFavicon
+
+  // Check if note title starts with a single emoji
+  const emojiMatch = note.title.match(emojiRegex())
+  if (emojiMatch && emojiMatch.index === 0) {
+    icon = emojiMatch[0]
+  }
 
   // Daily note
   if (isValidDateString(note.id)) {

--- a/src/components/note-list.tsx
+++ b/src/components/note-list.tsx
@@ -6,6 +6,8 @@ import { useDebouncedValue } from "../hooks/debounced-value"
 import { parseQuery, useSearchNotes } from "../hooks/search"
 import { useSearchParam } from "../hooks/search-param"
 import { templateSchema } from "../schema"
+import { removeLeadingEmoji } from "../utils/emoji"
+import { isPinned } from "../utils/pin"
 import { pluralize } from "../utils/pluralize"
 import { removeParentTags } from "../utils/remove-parent-tags"
 import { Button } from "./button"
@@ -20,7 +22,6 @@ import { NoteFavicon } from "./note-favicon"
 import { usePanel, usePanelActions } from "./panels"
 import { PillButton } from "./pill-button"
 import { SearchInput } from "./search-input"
-import { isPinned } from "../utils/pin"
 
 const viewTypeSchema = z.enum(["list", "cards"])
 
@@ -268,7 +269,7 @@ export function NoteList({ baseQuery = "" }: NoteListProps) {
                         <span className="text-text">
                           {parsedTemplate.success
                             ? `${parsedTemplate.data.name} template`
-                            : note.title || note.id}
+                            : removeLeadingEmoji(note.title) || note.id}
                         </span>
                         <span className="ml-2 ">
                           {removeParentTags(note.tags)

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -3,7 +3,7 @@ import emojiRegex from "emoji-regex"
 export function getLeadingEmoji(str: string): string | null {
   const matches = [...str.matchAll(emojiRegex())]
 
-  if (matches.length === 0 && matches[0].index === 0) {
+  if (matches.length > 0 && matches[0].index === 0) {
     return matches[0][0]
   }
 

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -1,0 +1,21 @@
+import emojiRegex from "emoji-regex"
+
+export function getLeadingEmoji(str: string): string | null {
+  const matches = [...str.matchAll(emojiRegex())]
+
+  if (matches.length === 0 || matches[0].index > 0) {
+    return null
+  }
+
+  return matches[0][0]
+}
+
+export function removeLeadingEmoji(str: string): string {
+  const leadingEmoji = getLeadingEmoji(str)
+
+  if (!leadingEmoji) {
+    return str
+  }
+
+  return str.slice(leadingEmoji.length)
+}

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -3,19 +3,19 @@ import emojiRegex from "emoji-regex"
 export function getLeadingEmoji(str: string): string | null {
   const matches = [...str.matchAll(emojiRegex())]
 
-  if (matches.length === 0 || matches[0].index > 0) {
-    return null
+  if (matches.length === 0 && matches[0].index === 0) {
+    return matches[0][0]
   }
 
-  return matches[0][0]
+  return null
 }
 
 export function removeLeadingEmoji(str: string): string {
   const leadingEmoji = getLeadingEmoji(str)
 
-  if (!leadingEmoji) {
-    return str
+  if (leadingEmoji) {
+    return str.slice(leadingEmoji.length)
   }
 
-  return str.slice(leadingEmoji.length)
+  return str
 }

--- a/src/utils/parse-note.ts
+++ b/src/utils/parse-note.ts
@@ -1,13 +1,14 @@
 import memoize from "fast-memoize"
 import { fromMarkdown } from "mdast-util-from-markdown"
+import { Node } from "mdast-util-from-markdown/lib"
 import { gfmTaskListItemFromMarkdown } from "mdast-util-gfm-task-list-item"
 import { toString } from "mdast-util-to-string"
 import { gfmTaskListItem } from "micromark-extension-gfm-task-list-item"
 import { visit } from "unist-util-visit"
 import { z } from "zod"
 import { embed, embedFromMarkdown } from "../remark-plugins/embed"
-import { wikilink, wikilinkFromMarkdown } from "../remark-plugins/wikilink"
 import { tag, tagFromMarkdown } from "../remark-plugins/tag"
+import { wikilink, wikilinkFromMarkdown } from "../remark-plugins/wikilink"
 import { NoteId } from "../schema"
 import { getNextBirthday, isValidDateString, toDateStringUtc } from "./date"
 import { parseFrontmatter } from "./parse-frontmatter"
@@ -28,24 +29,7 @@ export const parseNote = memoize((text: string) => {
 
   const { frontmatter, content } = parseFrontmatter(text)
 
-  const mdast = fromMarkdown(
-    content,
-    // @ts-ignore TODO: Fix types
-    {
-      // It's important that embed is included after wikilink.
-      // embed is a subset of wikilink. In other words, all embeds are also wikilinks.
-      // If embed is included before wikilink, all embeds are parsed as wikilinks.
-      extensions: [gfmTaskListItem(), wikilink(), embed(), tag()],
-      mdastExtensions: [
-        gfmTaskListItemFromMarkdown(),
-        wikilinkFromMarkdown(),
-        embedFromMarkdown(),
-        tagFromMarkdown(),
-      ],
-    },
-  )
-
-  visit(mdast, (node) => {
+  function visitNode(node: Node) {
     switch (node.type) {
       case "heading": {
         // Only use the first heading
@@ -91,7 +75,35 @@ export const parseNote = memoize((text: string) => {
         break
       }
     }
-  })
+  }
+  // It's important that embed is included after wikilink.
+  // embed is a subset of wikilink. In other words, all embeds are also wikilinks.
+  // If embed is included before wikilink, all embeds are parsed as wikilinks.
+  const extensions = [gfmTaskListItem(), wikilink(), embed(), tag()]
+  const mdastExtensions = [
+    gfmTaskListItemFromMarkdown(),
+    wikilinkFromMarkdown(),
+    embedFromMarkdown(),
+    tagFromMarkdown(),
+  ]
+
+  const contentMdast = fromMarkdown(
+    content,
+    // @ts-ignore TODO: Fix types
+    { extensions, mdastExtensions },
+  )
+
+  visit(contentMdast, visitNode)
+
+  // Parse frontmatter as markdown to find things like wikilinks and tags
+  const frontmatterString = text.slice(0, text.length - content.length)
+  const frontmatterMdast = fromMarkdown(
+    frontmatterString,
+    // @ts-ignore TODO: Fix types
+    { extensions, mdastExtensions },
+  )
+
+  visit(frontmatterMdast, visitNode)
 
   // Check for dates in the frontmatter
   for (const value of Object.values(frontmatter)) {

--- a/src/utils/parse-note.ts
+++ b/src/utils/parse-note.ts
@@ -76,6 +76,7 @@ export const parseNote = memoize((text: string) => {
       }
     }
   }
+  
   // It's important that embed is included after wikilink.
   // embed is a subset of wikilink. In other words, all embeds are also wikilinks.
   // If embed is included before wikilink, all embeds are parsed as wikilinks.


### PR DESCRIPTION
Implements the feature to display a single emoji as the favicon if a note title starts with an emoji in `note-favicon.tsx`.
- **Emoji Detection**: Adds a condition to check if the note title starts with a single emoji using the `emoji-regex` package. If a single emoji is detected at the beginning of the note title, it is set as the favicon.
- **Dependency Addition**: Imports `emojiRegex` from the `emoji-regex` package to facilitate the detection of emojis in note titles.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lumen-notes/lumen?shareId=6cdc0288-3af2-4beb-ba52-aa12ceed5aef).