### PR TITLE
Fix the SVG favicon for notes that start with emojis to be overflow visible

### DIFF
--- a/src/components/note-favicon.tsx
+++ b/src/components/note-favicon.tsx
@@ -26,7 +26,7 @@ export function NoteFavicon({
   const leadingEmoji = getLeadingEmoji(note.title)
   if (leadingEmoji) {
     icon = (
-      <svg className="h-4 w-4" viewBox="0 0 16 16">
+      <svg className="h-4 w-4 overflow-visible" viewBox="0 0 16 16">
         <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize={16}>
           {leadingEmoji}
         </text>


### PR DESCRIPTION
Set the `overflow` property to `visible` for the `svg` element displaying the leading emoji in the `NoteFavicon` component.

* Modify `src/components/note-favicon.tsx` to add the `overflow-visible` class to the `svg` element displaying the leading emoji.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace-dev.githubnext.com/lumen-notes/lumen?shareId=4cf28d65-4e27-4de9-aa3b-74d20931e10b).