### PR TITLE
Fix button width in repo form

### DIFF
--- a/src/components/repo-form.tsx
+++ b/src/components/repo-form.tsx
@@ -7,6 +7,7 @@ import { Card } from "./card"
 import { ErrorIcon16, LoadingIcon16 } from "./icons"
 import { RadioGroup } from "./radio-group"
 import { TextInput } from "./text-input"
+import { cx } from "../utils/cx"
 
 type RepoFormProps = {
   onSubmit?: (repo: GitHubRepository) => void
@@ -173,11 +174,18 @@ export function RepoForm({ onSubmit, onCancel }: RepoFormProps) {
             ) : null}
             <Button
               type="submit"
-              className="w-full flex-grow"
+              className="relative w-full flex-grow"
               variant="primary"
               disabled={isLoading}
             >
-              {isLoading ? <LoadingIcon16 /> : repoType === "new" ? "Create" : "Select"}
+              <span className={cx({ invisible: isLoading })}>
+                {repoType === "new" ? "Create" : "Select"}
+              </span>
+              {isLoading ? (
+                <span className="absolute inset-0 grid place-items-center">
+                  <LoadingIcon16 />
+                </span>
+              ) : null}
             </Button>
           </div>
           {error ? (


### PR DESCRIPTION
Update the submit button in the repo form to maintain its width when transitioning to a loading spinner.

* Add `cx` utility import to handle classnames.
* Wrap the button text in a `span` element and add the `invisible` class when `isLoading` is true.
* Add a `relative` class to the button element.
* Wrap the loading spinner in a `span` element and add the `absolute`, `inset-0`, and `grid place-items-center` classes to center the spinner within the button.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace-dev.githubnext.com/lumen-notes/lumen?shareId=50b6cd6d-3184-461c-a1e1-0ebeccb8c0e5).