### PR TITLE
Don't scale the book cover on hover

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -223,7 +223,7 @@ function MarkdownContent({ children, className }: { children: string; className?
 function BookCover({ isbn }: { isbn: string }) {
   return (
     <a
-      className="focus-ring inline-block aspect-[2/3] h-14 rounded-xs bg-bg-secondary bg-cover bg-center shadow-sm ring-1 ring-inset ring-border-secondary transition-[box-shadow,transform] [transform-origin:center_left] hover:shadow-md hover:[transform:perspective(30rem)_scale(1.05)_rotate3d(0,1,0,-20deg)]"
+      className="focus-ring inline-block aspect-[2/3] h-14 rounded-xs bg-bg-secondary bg-cover bg-center shadow-sm ring-1 ring-inset ring-border-secondary transition-[box-shadow] hover:shadow-md"
       href={`https://openlibrary.org/isbn/${isbn}`}
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
Remove the scaling effect on hover for the book cover in the `BookCover` component.

* Remove the CSS class `hover:[transform:perspective(30rem)_scale(1.05)_rotate3d(0,1,0,-20deg)]` from the `BookCover` component in `src/components/markdown.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace-dev.githubnext.com/lumen-notes/lumen?shareId=536e7f56-87ca-4343-b466-51720c44a803).