### PR TITLE
Check for email.visibility also when looking for user email.

### DIFF
--- a/netlify/edge-functions/github-auth.ts
+++ b/netlify/edge-functions/github-auth.ts
@@ -73,7 +73,7 @@ async function getUser(token: string) {
   const primaryEmail = emails.find((email) => email.primary && email.visibility === "public")
 
   if (!primaryEmail) {
-    throw new Error("No primary email found")
+    throw new Error("No public primary email found. Check your privacy settings in https://github.com/settings/emails")
   }
 
   return { login, name, email: primaryEmail.email }

--- a/netlify/edge-functions/github-auth.ts
+++ b/netlify/edge-functions/github-auth.ts
@@ -69,8 +69,8 @@ async function getUser(token: string) {
     throw new Error("Error getting user's emails")
   }
 
-  const emails = (await emailResponse.json()) as Array<{ email: string; primary: boolean }>
-  const primaryEmail = emails.find((email) => email.primary)
+  const emails = (await emailResponse.json()) as Array<{ email: string; primary: boolean; visibility: string }>
+  const primaryEmail = emails.find((email) => email.primary && email.visibility === "public")
 
   if (!primaryEmail) {
     throw new Error("No primary email found")


### PR DESCRIPTION
As exposed in #436, when the app tries to do a push action with an email address that is private, the action will fail.

```
[start] git push
onMessage error:GH007: Your push would publish a private email address.
onMessage You can make your email public or disable this protection by visiting:
onMessage https://github.com/settings/emails
GitPushError: One or more branches were not updated: 
  - refs/heads/main: push declined due to email privacy restrictions
    at gEe (index-03b654cd.js:456:40)
    at async Object.vEe [as push] (index-03b654cd.js:456:332)
    at async cDe (index-03b654cd.js:501:34563)
    at async push (index-03b654cd.js:614:5288)
```

In order to avoid this, it is necessary to check whether user's email visibility is public. According to the response schema of [/users/emails/ endpoint](https://docs.github.com/en/rest/users/emails#list-email-addresses-for-the-authenticated-user), this can be achieved by checking the `visibility` property of the response.

This PR aims to implement this check. Thanks.