### PR TITLE
Choose a public email to use the app

### DIFF
--- a/netlify/edge-functions/github-auth.ts
+++ b/netlify/edge-functions/github-auth.ts
@@ -70,10 +70,10 @@ async function getUser(token: string) {
   }
 
   const emails = (await emailResponse.json()) as Array<{ email: string; primary: boolean; visibility: string }>
-  const primaryEmail = emails.find((email) => email.primary && email.visibility === "public")
+  const primaryEmail = emails.find((email) => email.visibility === "public")
 
   if (!primaryEmail) {
-    throw new Error("No public primary email found. Check your privacy settings in https://github.com/settings/emails")
+    throw new Error("No public email found. Check your email settings in https://github.com/settings/emails")
   }
 
   return { login, name, email: primaryEmail.email }


### PR DESCRIPTION
This PR makes the app to look for a public email to login, regardless of whether it is primary or not.