### PR TITLE
Check now if email is not private instead

### DIFF
--- a/netlify/edge-functions/github-auth.ts
+++ b/netlify/edge-functions/github-auth.ts
@@ -70,7 +70,7 @@ async function getUser(token: string) {
   }
 
   const emails = (await emailResponse.json()) as Array<{ email: string; primary: boolean; visibility: string }>
-  const primaryEmail = emails.find((email) => email.visibility === "public")
+  const primaryEmail = emails.find((email) => email.visibility !== "private")
 
   if (!primaryEmail) {
     throw new Error("No public email found. Check your email settings in https://github.com/settings/emails")


### PR DESCRIPTION
Hello.

I'm writing again regarding the issue of not being able to log in due to the privacy email problem. Today, I faced again the issue with another account of mine.

By checking the "/user/emails" API endpoint with [Github CLI](https://docs.github.com/es/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#making-a-request), I discovered that sometimes the "visibility" field is null. With this PR, I propose that the app should look for the first email that is not private, instead of looking for the first public one.

I believe this PR will finally resolve issue #436.

Thank you for considering this improvement.

![image](https://github.com/user-attachments/assets/81168809-8833-4738-8886-c87da838ae30)

