### PR TITLE
feat: improve note title display

### DIFF
--- a/src/components/nav-items.tsx
+++ b/src/components/nav-items.tsx
@@ -2,7 +2,7 @@ import { Link, LinkComponentProps } from "@tanstack/react-router"
 import { useAtomValue, useSetAtom } from "jotai"
 import { selectAtom } from "jotai/utils"
 import { ComponentPropsWithoutRef, createContext, useContext } from "react"
-import { globalStateMachineAtom, notesAtom, pinnedNotesAtom } from "../global-state"
+import { globalStateMachineAtom, notesAtom, pinnedNotesAtom, sortedNotesAtom } from "../global-state"
 import { cx } from "../utils/cx"
 import { toDateString, toWeekString } from "../utils/date"
 import {
@@ -30,6 +30,7 @@ const SizeContext = createContext<"medium" | "large">("medium")
 
 export function NavItems({ size = "medium" }: { size?: "medium" | "large" }) {
   const pinnedNotes = useAtomValue(pinnedNotesAtom)
+  const recentNotes = useAtomValue(sortedNotesAtom).slice(0, 5) // Get 5 most recent notes
   const hasDailyNote = useAtomValue(hasDailyNoteAtom)
   const hasWeeklyNote = useAtomValue(hasWeeklyNoteAtom)
   const syncText = useSyncStatusText()
@@ -113,6 +114,29 @@ export function NavItems({ size = "medium" }: { size?: "medium" | "large" }) {
               </div>
               <ul className="flex flex-col gap-1">
                 {pinnedNotes.map((note) => (
+                  <li key={note.id} className="flex">
+                    <NavLink
+                      key={note.id}
+                      to={`/notes/$`}
+                      params={{ _splat: note.id }}
+                      search={{ mode: "read", query: undefined, view: "grid" }}
+                      icon={<NoteFavicon note={note} />}
+                      className="w-0 flex-1"
+                    >
+                      {note.displayName}
+                    </NavLink>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {recentNotes.length > 0 ? (
+            <div className="flex flex-col gap-1">
+              <div className="flex h-8 items-center px-2 text-sm text-text-secondary coarse:h-10 coarse:px-3">
+                Recents
+              </div>
+              <ul className="flex flex-col gap-1">
+                {recentNotes.map((note) => (
                   <li key={note.id} className="flex">
                     <NavLink
                       key={note.id}

--- a/src/utils/parse-note.ts
+++ b/src/utils/parse-note.ts
@@ -109,6 +109,14 @@ export const parseNote = memoize((id: NoteId, content: string): Note => {
 
   visit(contentMdast, visitNode)
 
+  // If no title was found from H1, try to use first line of content
+  if (!title && contentWithoutFrontmatter.trim()) {
+    const firstLine = contentWithoutFrontmatter.split('\n')[0].trim()
+    if (firstLine) {
+      title = firstLine
+    }
+  }
+
   // Parse frontmatter as markdown to find things like wikilinks and tags
   const frontmatterString = content.slice(0, content.length - contentWithoutFrontmatter.length)
   const frontmatterMdast = fromMarkdown(
@@ -186,11 +194,7 @@ export const parseNote = memoize((id: NoteId, content: string): Note => {
       if (title) {
         displayName = removeLeadingEmoji(title)
       }
-      // If there's no title but the ID contains non-numeric characters, use that as the display name
-      else if (!/^\d+$/.test(id)) {
-        displayName = id
-      }
-      // We consider notes with numeric IDs to untitled
+      // If there's no title but the content is not empty, use "Untitled note"
       else {
         displayName = "Untitled note"
       }


### PR DESCRIPTION
Use first line of content as title if no H1 header is present.
This improves user experience by:
- Not requiring users to know Markdown syntax
- Using the natural first line of text as title
- Making note titles more meaningful in navigation
- Fixing issues with pinned notes showing as "Untitled note"

Previously notes would show as "Untitled note" unless they had an H1
header, which was not intuitive for users. Now any text on the first
line will be used as the title making the behavior more natural.