### PR TITLE
[feat] note actions on command tool

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -34,6 +34,7 @@ import {
 import { NoteFavicon } from "./note-favicon"
 import { Route as NotesRoute } from "../routes/_appRoot.notes_.$"
 import { useAttachFile } from "../hooks/attach-file"
+import { useMatches } from "@tanstack/react-router"
 
 export const isCommandMenuOpenAtom = atom(false)
 
@@ -41,7 +42,10 @@ const hasDailyNoteAtom = selectAtom(notesAtom, (notes) => notes.has(toDateString
 const hasWeeklyNoteAtom = selectAtom(notesAtom, (notes) => notes.has(toWeekString(new Date())))
 
 export function CommandMenu() {
-  const { _splat: noteId } = NotesRoute.useParams()
+  const matches = useMatches()
+  const noteMatch = matches.find((match) => match.pathname.startsWith("/notes/"))
+  const noteId = noteMatch ? (noteMatch.params as { _splat: string })._splat : undefined
+  // const { _splat: noteId } = NotesRoute.useParams()
   const note = useNoteById(noteId)
   const attachFile = useAttachFile()
   const [copied, setCopied] = useState(false)
@@ -260,12 +264,11 @@ export function CommandMenu() {
               <CommandItem
                 icon={<PinIcon16 />}
                 onSelect={handleSelect(() => {
-                  if (!noteId) return
                   saveNote({
-                    id: noteId,
+                    id: note.id,
                     content: updateFrontmatter({
                       content: note.content,
-                      properties: { pinned: note.pinned ? null : true },
+                      properties: { pinned: note?.pinned ? false : true },
                     }),
                   })
                 })}

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -21,7 +21,6 @@ import {
   CopyIcon16,
   GlobeIcon16,
   NoteIcon16,
-  PaperclipIcon16,
   PinFillIcon12,
   PinIcon16,
   PlusIcon16,
@@ -32,7 +31,6 @@ import {
   CheckIcon16,
 } from "./icons"
 import { NoteFavicon } from "./note-favicon"
-import { Route as NotesRoute } from "../routes/_appRoot.notes_.$"
 import { useAttachFile } from "../hooks/attach-file"
 import { useMatches } from "@tanstack/react-router"
 


### PR DESCRIPTION
Tackles #447 

I left some comments on the other possible actions I couldn't connect.

- I had to use tanstack match to get the note id from the url because the Route from `"../routes/_appRoot.notes_.$"` throws an error when I'm in the home page.
- for the share note action, we'll either need a copy of `ShareDialog` inside `command-menu.tsx` or we have global state for that dialog and this way we can open it from the command menu.
- for the attach file action, it needs the `editorRef` and I'm not sure how to obtain it without props drilling 

https://github.com/user-attachments/assets/3f7a670a-1ead-4e77-b389-e2a032b4bb14


