### PR TITLE
[fix] prevent external link and arrow from wrapping separately

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -57,6 +57,10 @@ body:has([data-resizing="true"]) * {
   @apply decoration-solid;
 }
 
+.link-external {
+  white-space: nowrap;
+}
+
 .link-external::after {
   content: "";
   display: inline-block;


### PR DESCRIPTION
closes #254 

# Before
<img width="543" alt="image" src="https://github.com/user-attachments/assets/a8065519-1071-4cd1-a74f-9d68bbdcc9d3" />


# After
<img width="534" alt="image" src="https://github.com/user-attachments/assets/6f088949-bef0-444f-8736-61324c4abe2a" />
