### PR TITLE
[feat] ability to show frontmatter properties in the sidebar

### DIFF
--- a/src/components/frontmatter-sidebar.tsx
+++ b/src/components/frontmatter-sidebar.tsx
@@ -1,0 +1,30 @@
+import { useAtom } from "jotai"
+import { frontmatterSidebarAtom } from "../global-state"
+import { IconButton } from "./icon-button"
+import { ArrowLeftIcon16 } from "./icons"
+import { Frontmatter } from "./markdown"
+
+export function FrontmatterSidebar({ frontmatter }: { frontmatter: Record<string, unknown> }) {
+  const [isOpen, setIsOpen] = useAtom(frontmatterSidebarAtom)
+
+  if (!isOpen) return null
+
+  return (
+    <div className="right-2 absolute border rounded border-border-secondary grid w-64 flex-shrink-0 grid-rows-[auto_1fr] overflow-hidden">
+      <div className="flex w-full justify-between border-b border-border-secondary p-2">
+        <span className="text-sm font-medium">Properties</span>
+        <IconButton
+          aria-label="Close properties sidebar"
+          tooltipSide="left"
+          size="small"
+          onClick={() => setIsOpen(false)}
+        >
+          <ArrowLeftIcon16 />
+        </IconButton>
+      </div>
+      <div className="overflow-auto p-4">
+        <Frontmatter frontmatter={frontmatter} />
+      </div>
+    </div>
+  )
+}

--- a/src/global-state.ts
+++ b/src/global-state.ts
@@ -739,6 +739,8 @@ export const fontAtom = atomWithStorage<"sans" | "serif" | "handwriting">("font"
 
 export const sidebarAtom = atomWithStorage<"expanded" | "collapsed">("sidebar", "expanded")
 
+export const frontmatterSidebarAtom = atomWithStorage<boolean>("frontmatter-sidebar", false)
+
 export const widthAtom = atomWithStorage<"fixed" | "fill">("width", "fixed")
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- Introduced frontmatterSidebarAtom for managing the visibility of the frontmatter sidebar.
- Updated the Markdown component to utilize the new atom, allowing toggling of the sidebar.
- Adjusted layout to accommodate the sidebar's state, enhancing the user interface for note display.

# Demo


https://github.com/user-attachments/assets/e6a4fc2b-4a6d-497f-8c4b-516c094cf223

