### PR TITLE
Fix theme color typo

### DIFF
--- a/src/hooks/theme-color.ts
+++ b/src/hooks/theme-color.ts
@@ -4,7 +4,7 @@ import { themeAtom } from "../global-state"
 
 export const THEME_COLOR_VAR = "--color-bg"
 
-/** Dyanmically change the theme color */
+/** Dynamically change the theme color */
 export function useThemeColor() {
   const theme = useAtomValue(themeAtom)
 


### PR DESCRIPTION
## Summary
- fix a typo in theme color hook comment

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b96ef7c83218c2ff8c44661d592