### PR TITLE
Add ellipsis auto replace

### DIFF
--- a/src/codemirror-extensions/ellipsis.ts
+++ b/src/codemirror-extensions/ellipsis.ts
@@ -1,0 +1,32 @@
+import { EditorView } from "@codemirror/view"
+
+/**
+ * Replaces three consecutive dots with a single ellipsis character.
+ */
+export function ellipsisExtension() {
+  return EditorView.inputHandler.of((view, from, to, text) => {
+    // When typing a single '.' check if the previous two characters are '..'
+    if (
+      text === "." &&
+      from >= 2 &&
+      view.state.sliceDoc(from - 2, from) === ".."
+    ) {
+      view.dispatch({
+        changes: { from: from - 2, to, insert: "…" },
+        selection: { anchor: from - 1 },
+      })
+      return true
+    }
+
+    // When pasting or inserting three dots at once
+    if (text === "...") {
+      view.dispatch({
+        changes: { from, to, insert: "…" },
+        selection: { anchor: from + 1 },
+      })
+      return true
+    }
+
+    return false
+  })
+}

--- a/src/components/note-editor.tsx
+++ b/src/components/note-editor.tsx
@@ -20,6 +20,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { useAtomValue } from "jotai"
 import React from "react"
 import { frontmatterExtension } from "../codemirror-extensions/frontmatter"
+import { ellipsisExtension } from "../codemirror-extensions/ellipsis"
 import { headingExtension } from "../codemirror-extensions/heading"
 import { indentedLineWrapExtension } from "../codemirror-extensions/indented-line-wrap"
 import { pasteExtension } from "../codemirror-extensions/paste"
@@ -147,6 +148,7 @@ export const NoteEditor = React.forwardRef<ReactCodeMirrorRef, NoteEditorProps>(
           icons: false,
         }),
         frontmatterExtension(),
+        ellipsisExtension(),
         spellcheckExtension(),
         pasteExtension({ attachFile, onPaste }),
         indentedLineWrapExtension(),


### PR DESCRIPTION
## Summary
- replace three typed dots with the ellipsis character
- load the new CodeMirror extension in the note editor

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68431cb178f88321add03911bbc10aaa