### PR TITLE
Include daily note date in parsed dates

### DIFF
--- a/src/utils/parse-note.ts
+++ b/src/utils/parse-note.ts
@@ -174,6 +174,8 @@ function _parseNote(id: NoteId, content: string): Note {
   // Determine the type of the note
   if (isValidDateString(id)) {
     type = "daily"
+    // Add the daily note's date to its dates array
+    dates.add(id)
   } else if (isValidWeekString(id)) {
     type = "weekly"
   } else if (templateSchema.omit({ body: true }).safeParse(frontmatter.template).success) {


### PR DESCRIPTION
When parsing a note we previously only counted dates that were inserted as links. For daily notes this missed the date the note represents. Add the daily note's date to its dates array (deduped) so the parsed dates include the note's own date. This ensures daily notes correctly report their associated date in downstream processing.