### PR TITLE
Implement sort qualifier for search

### DIFF
--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -8,22 +8,24 @@ Search your notes with Lumen's [GitHub-style](https://docs.github.com/en/search-
 - Qualifiers can also be used to filter notes based on numerical ranges. To do this, use one of the following operators before the qualifier value: `>`, `<`, `>=`, `<=`. For example, `backlinks:>10` matches notes with more than 10 backlinks; `date:>=2021-01-01` matches notes with a date on or after `2021-01-01`.
 - Text outside of qualifiers is used to fuzzy search the note's title and body. For example, `tag:recipe cookie` matches notes with the `recipe` tag that also contain the word "cookie" in the title or body.
 - To search for a value that contains spaces, wrap the value in quotes. For example, `genre:"science fiction"` matches notes with `genre: science fiction` in their [frontmatter](/docs/metadata.md).
+- Use `sort:` to order results. For example, `sort:title`, `sort:id:desc`, or multiple keys `sort:title,tags:desc`. Direction can be `asc` or `desc`. Default is `asc` for `id` and `title`. `tags`, `links`, `backlinks` default to `desc`.
 
 ## Qualifiers
 
-| Key         | Example                                                                                                                                    |
-| :---------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`        | `id:1652342106359` matches the note with ID `1652342106359`.                                                                               |
-| `tag`       | `tag:recipe` matches notes with the `recipe` tag.                                                                                          |
-| `tags`      | `tags:>1` matches notes with more than one tag.                                                                                            |
-| `date`      | `date:2021-07-11` matches notes with the date `2021-07-11`.                                                                                |
-| `dates`     | `dates:>1` matches notes with more than one date.                                                                                          |
-| `link`      | `link:1652342106359` matches notes that link to the note with ID `1652342106359`.                                                          |
-| `links`     | `links:>1` matches notes with more than one link.                                                                                          |
-| `backlink`  | `backlink:1652342106359` matches notes that are linked to by the note with ID `1652342106359`.                                             |
-| `backlinks` | `backlinks:>1` matches notes with more than one backlink.                                                                                  |
-| `tasks`     | `tasks:>0` matches notes with at least one open task.                                                                                      |
-| `no`        | `no:tag` matches notes without a tag. `no` can be used with any qualifier key or frontmatter key.                                          |
-| `has`       | `has:tag` matches notes with one or more tag. `has` can be used with any qualifier key or frontmatter key. `has` and `-no` are equivalent. |
+| Key         | Example                                                                                                                                                                                                                                                                       |
+| :---------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | `id:1652342106359` matches the note with ID `1652342106359`.                                                                                                                                                                                                                  |
+| `tag`       | `tag:recipe` matches notes with the `recipe` tag.                                                                                                                                                                                                                             |
+| `tags`      | `tags:>1` matches notes with more than one tag.                                                                                                                                                                                                                               |
+| `date`      | `date:2021-07-11` matches notes with the date `2021-07-11`.                                                                                                                                                                                                                   |
+| `dates`     | `dates:>1` matches notes with more than one date.                                                                                                                                                                                                                             |
+| `link`      | `link:1652342106359` matches notes that link to the note with ID `1652342106359`.                                                                                                                                                                                             |
+| `links`     | `links:>1` matches notes with more than one link.                                                                                                                                                                                                                             |
+| `backlink`  | `backlink:1652342106359` matches notes that are linked to by the note with ID `1652342106359`.                                                                                                                                                                                |
+| `backlinks` | `backlinks:>1` matches notes with more than one backlink.                                                                                                                                                                                                                     |
+| `tasks`     | `tasks:>0` matches notes with at least one open task.                                                                                                                                                                                                                         |
+| `no`        | `no:tags` matches notes without a tag. `no` can be used with any filter qualifier key or frontmatter key.                                                                                                                                                                     |
+| `has`       | `has:tags` matches notes with one or more tag. `has` can be used with any filter qualifier key or frontmatter key.                                                                                                                                                            |
+| `sort`      | `sort:title`, `sort:id:desc`, `sort:tags,links:desc`. Supports `id`, `title`, `tags`, `links`, `backlinks`. Use `:asc` or `:desc`. Default is `asc` for `id` and `title`. `tags`, `links`, `backlinks` default to `desc`. Multiple comma-separated sorts apply left-to-right. |
 
 Unrecognized qualifier keys are assumed to be [frontmatter](/docs/metadata.md) keys. For example, `read:true` matches notes with `read: true` in their frontmatter.

--- a/src/components/new-note-button.tsx
+++ b/src/components/new-note-button.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useMatch, useNavigate } from "@tanstack/react-router"
-import { parseQuery } from "../hooks/search"
+import { parseQuery } from "../utils/search"
 import { IconButton } from "./icon-button"
 import { PlusIcon16 } from "./icons"
 
@@ -13,10 +13,10 @@ function useTagsFromRoute() {
 
   const location = useLocation()
   const query = location.search.query ?? ""
-  const tagQualifiers = parseQuery(query).qualifiers.filter((q) => q.key === "tag" && !q.exclude)
+  const tagFilters = parseQuery(query).filters.filter((q) => q.key === "tag" && !q.exclude)
 
-  tagQualifiers.forEach((qualifier) => {
-    qualifier.values.forEach((tag) => tags.add(tag))
+  tagFilters.forEach((filter) => {
+    filter.values.forEach((tag) => tags.add(tag))
   })
 
   return Array.from(tags)

--- a/src/hooks/search.ts
+++ b/src/hooks/search.ts
@@ -1,17 +1,21 @@
 import { useAtomValue } from "jotai"
 import React from "react"
+import type { FullOptions, Searcher as FuzzySearcher } from "fast-fuzzy"
 import { noteSearcherAtom, sortedNotesAtom } from "../global-state"
-import { Note } from "../schema"
+import { filterNotes, parseQuery, sortNotes } from "../utils/search"
+import type { Note } from "../schema"
 
-type Qualifier = {
-  key: string
-  values: string[]
-  exclude: boolean
-}
-
-type Query = {
-  qualifiers: Qualifier[]
-  fuzzy: string
+// Shared search routine used by both hooks
+function runSearch(
+  query: string,
+  sortedNotes: Note[],
+  noteSearcher: FuzzySearcher<Note, FullOptions<Note>>,
+) {
+  if (!query) return sortedNotes
+  const { fuzzy, filters, sorts } = parseQuery(query)
+  const results = fuzzy ? noteSearcher.search(fuzzy) : sortedNotes
+  const filtered = filterNotes(results, filters)
+  return sorts.length ? sortNotes(filtered, sorts) : filtered
 }
 
 export function useSearchNotes() {
@@ -20,12 +24,7 @@ export function useSearchNotes() {
 
   const searchNotes = React.useCallback(
     (query: string) => {
-      // If there's no query, return all notes
-      if (!query) return sortedNotes
-
-      const { fuzzy, qualifiers } = parseQuery(query)
-      const results = fuzzy ? noteSearcher.search(fuzzy) : sortedNotes
-      return filterResults(results, qualifiers)
+      return runSearch(query, sortedNotes, noteSearcher)
     },
     [sortedNotes, noteSearcher],
   )
@@ -51,212 +50,8 @@ export function useStableSearchNotes() {
   }, [noteSearcher])
 
   const searchNotes = React.useCallback((query: string) => {
-    // If there's no query, return all notes
-    if (!query) return sortedNotesRef.current
-
-    const { fuzzy, qualifiers } = parseQuery(query)
-    const results = fuzzy ? noteSearcherRef.current.search(fuzzy) : sortedNotesRef.current
-    return filterResults(results, qualifiers)
+    return runSearch(query, sortedNotesRef.current, noteSearcherRef.current)
   }, [])
 
   return searchNotes
-}
-
-// eslint-disable-next-line no-useless-escape
-const QUALIFIER_REGEX = /(?<exclude>-?)(?<key>\w+):(?<value>[^"\[\]| ]+|"[^"\[\]|]+")/g
-// Valid qualifiers:
-// - id:123
-// - id:"hello, world"
-
-export function parseQuery(query: string): Query {
-  const fuzzy = query.replace(QUALIFIER_REGEX, "").trim()
-  const matches = query.matchAll(QUALIFIER_REGEX)
-  const qualifiers: Qualifier[] = Array.from(matches)
-    .map((match) => {
-      if (!match.groups) return null
-
-      let values = []
-
-      if (match.groups.value.startsWith('"')) {
-        // If the value is quoted, remove the quotes
-        values = [match.groups.value.slice(1, -1)]
-      } else if (match.groups.value.includes(",")) {
-        // If the value is comma-separated, split it into an array
-        values = match.groups.value.split(",")
-      } else {
-        // Otherwise, just use the value as-is
-        values = [match.groups.value]
-      }
-
-      return {
-        key: match.groups.key,
-        values,
-        exclude: Boolean(match.groups.exclude),
-      }
-    })
-    .filter(Boolean)
-
-  return { fuzzy, qualifiers }
-}
-
-export function filterResults<T extends Note>(results: Array<T>, qualifiers: Qualifier[]) {
-  return results.filter((item) => {
-    if (!item) return false
-    return testQualifiers(qualifiers, item)
-  })
-}
-
-export function testQualifiers(qualifiers: Qualifier[], item: Note) {
-  return qualifiers.every((qualifier) => {
-    const frontmatter = item.frontmatter
-
-    let value = false
-
-    switch (qualifier.key) {
-      case "id":
-        // TODO: Add support for spaces in IDs
-        // Match if the item's ID is in the qualifier's values
-        value = qualifier.values.includes(item.id)
-        break
-
-      case "tag":
-        // Match if any of the item's tags are in the qualifier's values
-        value = item.tags.some((tag) => qualifier.values.includes(tag))
-        break
-
-      case "tags":
-        // Match if the item's tag count is in the qualifier's value range
-        value = qualifier.values.some((range) => isInRange(String(item.tags.length), range))
-        break
-
-      case "date":
-        // Match if any of the item's dates are in the qualifier's value ranges
-        value = item.dates.some((date) => {
-          return qualifier.values.some((value) => isInRange(date, value))
-        })
-        break
-
-      case "dates":
-        // Match if the item's date count is in the qualifier's value range
-        value = qualifier.values.some((range) => isInRange(item.dates.length, range))
-        break
-
-      case "link":
-        // Match if any of the item's links are in the qualifier's values
-        value = item.links.some((link) => qualifier.values.includes(link))
-        break
-
-      case "links":
-        // Match if the item's link count is in the qualifier's value range
-        value = qualifier.values.some((range) => isInRange(item.links.length, range))
-        break
-
-      case "backlink":
-        if (!("backlinks" in item)) return false
-        // Match if any of the item's backlinks are in the qualifier's values
-        value = item.backlinks.some((backlink) => qualifier.values.includes(backlink))
-        break
-
-      case "backlinks":
-        if (!("backlinks" in item)) return false
-        // Match if the item's backlink count is in the qualifier's value range
-        value = qualifier.values.some((value) => isInRange(item.backlinks.length, value))
-        break
-
-      case "tasks":
-        value = qualifier.values.some((value) =>
-          isInRange(item.tasks.filter((task) => !task.completed).length, value),
-        )
-        break
-
-      case "no":
-        // Match if the item doesn't have the specified property
-        value = qualifier.values.some((value) => {
-          switch (value) {
-            case "backlinks":
-              if (!("backlinks" in item)) return true
-              return item.backlinks.length === 0
-            case "tag":
-            case "tags":
-              return item.tags.length === 0
-            case "date":
-            case "dates":
-              return item.dates.length === 0
-            case "link":
-            case "links":
-              return item.links.length === 0
-            case "task":
-            case "tasks":
-              return item.tasks.filter((task) => !task.completed).length === 0
-            case "title":
-              return !item.title
-            default:
-              return !(value in frontmatter)
-          }
-        })
-        break
-
-      case "has":
-        // `has` is the opposite of `no`
-        value = !qualifier.values.some((value) => {
-          switch (value) {
-            case "backlinks":
-              if (!("backlinks" in item)) return false
-              return item.backlinks.length === 0
-            case "tag":
-            case "tags":
-              return item.tags.length === 0
-            case "date":
-            case "dates":
-              return item.dates.length === 0
-            case "link":
-            case "links":
-              return item.links.length === 0
-            case "task":
-            case "tasks":
-              return item.tasks.filter((task) => !task.completed).length === 0
-            case "title":
-              return !item.title
-            default:
-              return !(value in frontmatter)
-          }
-        })
-        break
-
-      case "is":
-      case "type":
-        if (qualifier.values.includes("published")) {
-          // Match if the item has a `gist_id` property (which means it's published)
-          value =
-            typeof item.frontmatter.gist_id === "string" && item.frontmatter.gist_id.length > 0
-        } else {
-          // Match if the item's type is in the qualifier's values
-          value = qualifier.values.includes(item.type)
-        }
-        break
-
-      default:
-        if (qualifier.key in frontmatter) {
-          // Match if the item's frontmatter value is in the qualifier's values
-          value = qualifier.values.includes(String(frontmatter[qualifier.key]))
-        }
-        break
-    }
-
-    return qualifier.exclude ? !value : value
-  })
-}
-
-function isInRange(value: string | number, range: string) {
-  if (range.startsWith(">=")) {
-    return value >= range.slice(2)
-  } else if (range.startsWith("<=")) {
-    return value <= range.slice(2)
-  } else if (range.startsWith(">")) {
-    return value > range.slice(1)
-  } else if (range.startsWith("<")) {
-    return value < range.slice(1)
-  } else {
-    return value.toString() === range
-  }
 }

--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test, vi } from "vitest"
+vi.mock("../global-state", () => ({
+  sortedNotesAtom: {},
+  noteSearcherAtom: {},
+}))
+import { filterNotes, parseQuery, sortNotes, testFilters } from "./search"
+import type { Note } from "../schema"
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: "1",
+    content: "",
+    type: "note",
+    displayName: "",
+    frontmatter: {},
+    title: "",
+    url: null,
+    alias: null,
+    pinned: false,
+    links: [],
+    dates: [],
+    tags: [],
+    tasks: [],
+    backlinks: [],
+    ...overrides,
+  }
+}
+
+describe("parseQuery", () => {
+  test("parses quoted values, comma lists, exclusions, and multiple sorts", () => {
+    const q = parseQuery('foo tag:a,b title:"hello, world" -tag:c sort:title,id:desc,links')
+    expect(q.fuzzy).toBe("foo")
+    expect(q.filters).toEqual([
+      { key: "tag", values: ["a", "b"], exclude: false },
+      { key: "title", values: ["hello, world"], exclude: false },
+      { key: "tag", values: ["c"], exclude: true },
+    ])
+    expect(q.sorts).toEqual([
+      { key: "title", direction: "asc" },
+      { key: "id", direction: "desc" },
+      { key: "links", direction: "desc" },
+    ])
+  })
+
+  test("treats unknown qualifiers as frontmatter filters and trims fuzzy", () => {
+    const q = parseQuery("hello priority:high")
+    expect(q.fuzzy).toBe("hello")
+    expect(q.filters).toEqual([{ key: "priority", values: ["high"], exclude: false }])
+  })
+
+  test("parses multiple sort qualifiers and ignores exclude on sort", () => {
+    const q = parseQuery("sort:title -sort:id:desc")
+    expect(q.sorts).toEqual([
+      { key: "title", direction: "asc" },
+      { key: "id", direction: "desc" },
+    ])
+  })
+
+  test("supports hyphenated keys and quoted values with commas and hyphens", () => {
+    const q = parseQuery('foo foo-bar:"a-b, c"')
+    expect(q.fuzzy).toBe("foo")
+    expect(q.filters).toEqual([{ key: "foo-bar", values: ["a-b, c"], exclude: false }])
+  })
+
+  test("trims fuzzy text and preserves inner spacing", () => {
+    const q = parseQuery("   hello   world   tag:a   ")
+    expect(q.fuzzy).toBe("hello   world")
+  })
+
+  test("applies default sort directions when omitted per key", () => {
+    const q = parseQuery("sort:tags:asc,links,backlinks:desc")
+    expect(q.sorts).toEqual([
+      { key: "tags", direction: "asc" },
+      { key: "links", direction: "desc" },
+      { key: "backlinks", direction: "desc" },
+    ])
+  })
+})
+
+describe("filtering", () => {
+  test("matches by tag, title, type, link and backlink, frontmatter, counts, dates, has and no filters", () => {
+    const note = makeNote({
+      type: "daily",
+      title: "Title 1",
+      frontmatter: { priority: "high" },
+      tasks: [
+        { completed: false, text: "do it" },
+        { completed: true, text: "done" },
+      ],
+      tags: ["a", "b"],
+      dates: ["2021-01-01", "2021-01-03"],
+      links: ["x"],
+      backlinks: ["y"],
+    })
+
+    expect(testFilters([{ key: "id", values: [note.id], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "title", values: [note.title], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "type", values: ["daily"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "tag", values: ["a"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "link", values: ["x"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "backlink", values: ["y"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "priority", values: ["high"], exclude: false }], note)).toBe(true)
+
+    expect(testFilters([{ key: "tags", values: [">=2"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "links", values: ["<2"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "backlinks", values: ["1"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "dates", values: ["2"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "tasks", values: [">=1"], exclude: false }], note)).toBe(true)
+
+    expect(testFilters([{ key: "date", values: [">=2021-01-02"], exclude: false }], note)).toBe(
+      true,
+    )
+
+    expect(testFilters([{ key: "has", values: ["backlinks"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "no", values: ["tags"], exclude: false }], note)).toBe(false)
+
+    expect(testFilters([{ key: "tag", values: ["a"], exclude: true }], note)).toBe(false)
+  })
+
+  test("AND semantics across multiple filters", () => {
+    const note = makeNote({ tags: ["a", "b"] })
+    const filters = [
+      { key: "tag", values: ["a"], exclude: false },
+      { key: "tag", values: ["b"], exclude: false },
+    ]
+    expect(testFilters(filters, note)).toBe(true)
+  })
+
+  test("filterNotes applies filters and removes non-matching notes", () => {
+    const notes = [
+      makeNote({ id: "1", tags: ["a"] }),
+      makeNote({ id: "2", tags: ["b"] }),
+      makeNote({ id: "3", tags: ["a", "b"] }),
+    ]
+    const filtered = filterNotes(notes, [{ key: "tag", values: ["a"], exclude: false }])
+    expect(filtered.map((n) => n.id)).toEqual(["1", "3"])
+  })
+
+  test("has and no on frontmatter keys consider presence not truthiness", () => {
+    const note = makeNote({ frontmatter: { read: false } })
+    expect(testFilters([{ key: "has", values: ["read"], exclude: false }], note)).toBe(true)
+    expect(testFilters([{ key: "no", values: ["read"], exclude: false }], note)).toBe(false)
+  })
+
+  test("has and no for title respect empty string and non-empty", () => {
+    const emptyTitle = makeNote({ title: "" })
+    const withTitle = makeNote({ title: "Hello" })
+    expect(testFilters([{ key: "no", values: ["title"], exclude: false }], emptyTitle)).toBe(true)
+    expect(testFilters([{ key: "has", values: ["title"], exclude: false }], emptyTitle)).toBe(false)
+    expect(testFilters([{ key: "has", values: ["title"], exclude: false }], withTitle)).toBe(true)
+  })
+
+  test("AND with exclusion allows include and exclude combinations", () => {
+    const aOnly = makeNote({ id: "1", tags: ["a"] })
+    const aAndB = makeNote({ id: "2", tags: ["a", "b"] })
+    const filters = [
+      { key: "tag", values: ["a"], exclude: false },
+      { key: "tag", values: ["b"], exclude: true },
+    ]
+    expect(testFilters(filters, aOnly)).toBe(true)
+    expect(testFilters(filters, aAndB)).toBe(false)
+  })
+
+  test("task count filters match incomplete task counts with range operators", () => {
+    const note = makeNote({ tasks: [{ completed: false, text: "x" }] })
+    expect(testFilters([{ key: "tasks", values: ["0"], exclude: false }], note)).toBe(false)
+    expect(testFilters([{ key: "tasks", values: ["<=1"], exclude: false }], note)).toBe(true)
+  })
+})
+
+describe("sorting", () => {
+  test("sorts by tag count desc then id asc with punctuation and case ignored", () => {
+    const notes = [
+      makeNote({ id: "note-2", displayName: "A-2", tags: ["x"] }),
+      makeNote({ id: "note 10", displayName: "A-1", tags: ["x", "y"] }),
+      makeNote({ id: "note-1", displayName: "A-1", tags: [] }),
+    ]
+    const sorted = sortNotes(notes, [
+      { key: "tags", direction: "desc" },
+      { key: "id", direction: "asc" },
+    ])
+    expect(sorted.map((n) => n.id)).toEqual(["note 10", "note-2", "note-1"])
+  })
+
+  test("title sort ignores punctuation and case (asc) with id tiebreaker", () => {
+    const notes = [
+      makeNote({ id: "1", displayName: "B-2" }),
+      makeNote({ id: "2", displayName: "A 1" }),
+      makeNote({ id: "3", displayName: "A-1" }),
+    ]
+    const sorted = sortNotes(notes, [
+      { key: "title", direction: "asc" },
+      { key: "id", direction: "asc" },
+    ])
+    expect(sorted.map((n) => n.id)).toEqual(["2", "3", "1"]) // A(1) then B(2)
+  })
+
+  test("unknown sort key is ignored and next sort applies", () => {
+    const notes = [makeNote({ id: "2", displayName: "A" }), makeNote({ id: "1", displayName: "A" })]
+    const sorted = sortNotes(notes, [
+      { key: "unknown", direction: "desc" },
+      { key: "id", direction: "asc" },
+    ])
+    expect(sorted.map((n) => n.id)).toEqual(["1", "2"])
+  })
+
+  test("numeric collation sorts ids with embedded numbers in natural order", () => {
+    const notes = [
+      makeNote({ id: "note 2", displayName: "X" }),
+      makeNote({ id: "note 10", displayName: "X" }),
+      makeNote({ id: "note 1", displayName: "X" }),
+    ]
+    const sorted = sortNotes(notes, [{ key: "id", direction: "asc" }])
+    expect(sorted.map((n) => n.id)).toEqual(["note 1", "note 2", "note 10"])
+  })
+})
+
+describe("integration: parse + filter + sort", () => {
+  test("filters by tag and sorts by title asc with punctuation ignored", () => {
+    const notes = [
+      makeNote({ id: "1", displayName: "B--", tags: ["a"] }),
+      makeNote({ id: "2", displayName: "A!!", tags: ["a"] }),
+      makeNote({ id: "3", displayName: "C??", tags: ["b"] }),
+    ]
+    const { filters, sorts } = parseQuery("tag:a sort:title")
+    const filtered = filterNotes(notes, filters)
+    const sorted = sortNotes(filtered, sorts)
+    expect(sorted.map((n) => n.id)).toEqual(["2", "1"]) // A before B
+  })
+
+  test("default sort direction for links count is desc", () => {
+    const notes = [
+      makeNote({ id: "1", links: [] }),
+      makeNote({ id: "2", links: ["x"] }),
+      makeNote({ id: "3", links: ["x", "y"] }),
+    ]
+    const { sorts } = parseQuery("sort:links")
+    const sorted = sortNotes(notes, sorts)
+    expect(sorted.map((n) => n.id)).toEqual(["3", "2", "1"]) // desc by links count
+  })
+
+  test("exclusion filter excludes notes with matching tags", () => {
+    const notes = [makeNote({ id: "1", tags: ["foo"] }), makeNote({ id: "2", tags: [] })]
+    const { filters } = parseQuery("-tag:foo")
+    const filtered = filterNotes(notes, filters)
+    expect(filtered.map((n) => n.id)).toEqual(["2"])
+  })
+})

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,265 @@
+import type { Note } from "../schema"
+
+export type Filter = {
+  key: string
+  values: string[]
+  exclude: boolean
+}
+
+export type SortDirection = "asc" | "desc"
+
+export type Sort = {
+  key: string
+  direction: SortDirection
+}
+
+export type Query = {
+  filters: Filter[]
+  fuzzy: string
+  sorts: Sort[]
+}
+
+// eslint-disable-next-line no-useless-escape
+const QUALIFIER_REGEX = /(?<exclude>-?)(?<key>[-\w]+):(?<value>[^"\[\]| ]+|"[^"\[\]|]+")/g
+
+export function parseQuery(query: string): Query {
+  const sorts: Sort[] = []
+  const filters: Filter[] = []
+
+  const matches = Array.from(query.matchAll(QUALIFIER_REGEX))
+
+  for (const match of matches) {
+    if (!match.groups) continue
+
+    const key = match.groups.key
+    const value = match.groups.value
+    const exclude = Boolean(match.groups.exclude)
+
+    if (key === "sort") {
+      const values = value.split(",")
+
+      for (const sort of values) {
+        const [key, direction] = sort.trim().split(":")
+
+        sorts.push({
+          key,
+          direction: getSortDirection(key, direction),
+        })
+      }
+
+      continue
+    }
+
+    let values = [] as string[]
+    if (value.startsWith('"')) {
+      values = [value.slice(1, -1)]
+    } else if (value.includes(",")) {
+      values = value
+        .split(",")
+        .map((v) => v.trim())
+        .filter(Boolean)
+    } else {
+      values = [value.trim()]
+    }
+
+    filters.push({ key, values, exclude })
+  }
+
+  const fuzzy = query.replace(QUALIFIER_REGEX, "").trim()
+
+  return { fuzzy, filters, sorts }
+}
+
+function getSortDirection(key: string, direction?: string): SortDirection {
+  if (direction === "asc") return "asc"
+  if (direction === "desc") return "desc"
+  if (["tags", "links", "backlinks"].includes(key)) return "desc"
+  return "asc"
+}
+
+export function filterNotes(results: Array<Note>, filters: Filter[]) {
+  return results.filter((note) => {
+    if (!note) return false
+    return testFilters(filters, note)
+  })
+}
+
+export function testFilters(filters: Filter[], note: Note) {
+  return filters.every((filter) => testFilter(filter, note))
+}
+
+export function testFilter(filter: Filter, note: Note) {
+  const frontmatter = note.frontmatter
+
+  let value = false
+
+  switch (filter.key) {
+    case "id":
+      value = filter.values.includes(note.id)
+      break
+    case "title":
+      value = filter.values.includes(note.title)
+      break
+    case "tag":
+      value = note.tags.some((tag) => filter.values.includes(tag))
+      break
+    case "tags":
+      value = filter.values.some((range) => isInRange(String(note.tags.length), range))
+      break
+    case "date":
+      value = note.dates.some((date) => {
+        return filter.values.some((value) => isInRange(date, value))
+      })
+      break
+    case "dates":
+      value = filter.values.some((range) => isInRange(note.dates.length, range))
+      break
+    case "link":
+      value = note.links.some((link) => filter.values.includes(link))
+      break
+    case "links":
+      value = filter.values.some((range) => isInRange(note.links.length, range))
+      break
+    case "backlink":
+      if (!("backlinks" in note)) return false
+      value = note.backlinks.some((backlink) => filter.values.includes(backlink))
+      break
+    case "backlinks":
+      if (!("backlinks" in note)) return false
+      value = filter.values.some((value) => isInRange(note.backlinks.length, value))
+      break
+    case "tasks":
+      value = filter.values.some((value) =>
+        isInRange(note.tasks.filter((task) => !task.completed).length, value),
+      )
+      break
+    case "no":
+      value = filter.values.some((value) => {
+        switch (value) {
+          case "backlink":
+          case "backlinks":
+            return !("backlinks" in note) || note.backlinks.length === 0
+          case "tag":
+          case "tags":
+            return note.tags.length === 0
+          case "date":
+          case "dates":
+            return note.dates.length === 0
+          case "link":
+          case "links":
+            return note.links.length === 0
+          case "task":
+          case "tasks":
+            return note.tasks.filter((task) => !task.completed).length === 0
+          case "title":
+            return !note.title
+          default:
+            return !(value in frontmatter)
+        }
+      })
+      break
+    case "has":
+      value = filter.values.some((value) => {
+        switch (value) {
+          case "backlink":
+          case "backlinks":
+            return "backlinks" in note && note.backlinks.length > 0
+          case "tag":
+          case "tags":
+            return note.tags.length > 0
+          case "date":
+          case "dates":
+            return note.dates.length > 0
+          case "link":
+          case "links":
+            return note.links.length > 0
+          case "task":
+          case "tasks":
+            return note.tasks.filter((task) => !task.completed).length > 0
+          case "title":
+            return Boolean(note.title)
+          default:
+            return value in frontmatter
+        }
+      })
+      break
+    case "type":
+      value = filter.values.includes(note.type)
+      break
+    default:
+      if (filter.key in frontmatter) {
+        value = filter.values.includes(String(frontmatter[filter.key]))
+      }
+      break
+  }
+
+  return filter.exclude ? !value : value
+}
+
+export function sortNotes(results: Array<Note>, sorts: Sort[]): Array<Note> {
+  return [...results].sort((a, b) => compareNotes(a, b, sorts))
+}
+
+const collator = new Intl.Collator(undefined, {
+  sensitivity: "base",
+  numeric: true,
+  ignorePunctuation: true,
+})
+
+function compareNotes(a: Note, b: Note, sorts: Sort[]) {
+  for (const sort of sorts) {
+    let compareResult = 0
+
+    switch (sort.key) {
+      case "id": {
+        compareResult = collator.compare(a.id, b.id)
+        break
+      }
+      case "title": {
+        compareResult = collator.compare(a.displayName, b.displayName)
+        break
+      }
+      case "tags": {
+        const aTagCount = a.tags.length
+        const bTagCount = b.tags.length
+        compareResult = aTagCount - bTagCount
+        break
+      }
+      case "links": {
+        const aLinkCount = a.links.length
+        const bLinkCount = b.links.length
+        compareResult = aLinkCount - bLinkCount
+        break
+      }
+      case "backlinks": {
+        const aBacklinkCount = "backlinks" in a ? a.backlinks.length : 0
+        const bBacklinkCount = "backlinks" in b ? b.backlinks.length : 0
+        compareResult = aBacklinkCount - bBacklinkCount
+        break
+      }
+      default: {
+        continue
+      }
+    }
+
+    if (compareResult !== 0) {
+      return sort.direction === "desc" ? -compareResult : compareResult
+    }
+  }
+
+  return 0
+}
+
+function isInRange(value: string | number, range: string) {
+  if (range.startsWith(">=")) {
+    return value >= range.slice(2)
+  } else if (range.startsWith("<=")) {
+    return value <= range.slice(2)
+  } else if (range.startsWith(">")) {
+    return value > range.slice(1)
+  } else if (range.startsWith("<")) {
+    return value < range.slice(1)
+  } else {
+    return value.toString() === range
+  }
+}


### PR DESCRIPTION
- Add support for a `sort:` qualifier in search queries
- Parse and apply the sort qualifier when executing searches
- Ensure search results are ordered according to the specified sort criterion