### PR TITLE
Show draft note content in note previews

### DIFF
--- a/src/components/draft-indicator.tsx
+++ b/src/components/draft-indicator.tsx
@@ -1,0 +1,10 @@
+import { cx } from "../utils/cx"
+import { DotIcon8 } from "./icons"
+
+export function DraftIndicator({ className }: { className?: string }) {
+  return (
+    <div aria-label="Unsaved changes" className={cx("grid place-items-center size-4", className)}>
+      <DotIcon8 className="text-text-pending" />
+    </div>
+  )
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -9,7 +9,7 @@ function Icon({ size, className, ...props }: IconProps & { size: number }) {
       height={size}
       viewBox={`0 0 ${size} ${size}`}
       fill="currentColor"
-      aria-hidden
+      aria-hidden="true"
       className={cx(
         "flex-shrink-0 overflow-visible",
         // 16px icons scale to 20px on touch devices

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement)
   root.render(
     <StrictMode>
-      <Tooltip.Provider delayDuration={100}>
+      <Tooltip.Provider delayDuration={200}>
         <RouterProvider router={router} />
       </Tooltip.Provider>
     </StrictMode>,

--- a/src/utils/note-draft.ts
+++ b/src/utils/note-draft.ts
@@ -1,0 +1,96 @@
+import { GitHubRepository, NoteId } from "../schema"
+
+const DRAFT_PREFIX = "draft" as const
+const DRAFT_DEBOUNCE_MS = 500
+
+// Keep track of pending debounced writes per storage key so we can
+// coalesce rapid updates and cancel when clearing a draft
+const draftWriteTimers = new Map<string, number>()
+
+function getNoteStorageKey({
+  githubRepo,
+  noteId,
+}: {
+  githubRepo: GitHubRepository | null
+  noteId: NoteId
+}) {
+  if (!githubRepo) return `${DRAFT_PREFIX}::${noteId}`
+  const owner = githubRepo.owner.trim().toLowerCase()
+  const name = githubRepo.name.trim().toLowerCase()
+  return `${DRAFT_PREFIX}:${owner}/${name}::${noteId}`
+}
+
+export function getNoteDraft({
+  githubRepo,
+  noteId,
+}: {
+  githubRepo: GitHubRepository | null
+  noteId: NoteId
+}) {
+  if (typeof window === "undefined" || !window.localStorage) return null
+
+  try {
+    const key = getNoteStorageKey({ githubRepo, noteId })
+    return window.localStorage.getItem(key)
+  } catch {
+    // Ignore storage errors (e.g., private mode restrictions)
+    return null
+  }
+}
+
+export function setNoteDraft({
+  githubRepo,
+  noteId,
+  value,
+}: {
+  githubRepo: GitHubRepository | null
+  noteId: NoteId
+  value: string
+}) {
+  if (typeof window === "undefined" || !window.localStorage) return
+
+  try {
+    const key = getNoteStorageKey({ githubRepo, noteId })
+    // Debounce writes to reduce pressure on localStorage
+    const existingTimerId = draftWriteTimers.get(key)
+    if (existingTimerId !== undefined) {
+      window.clearTimeout(existingTimerId)
+    }
+    const timeoutId = window.setTimeout(() => {
+      try {
+        window.localStorage.setItem(key, value)
+      } catch {
+        // Ignore storage errors (e.g., private mode restrictions)
+      } finally {
+        draftWriteTimers.delete(key)
+      }
+    }, DRAFT_DEBOUNCE_MS)
+    draftWriteTimers.set(key, timeoutId)
+  } catch {
+    // Ignore storage errors (e.g., private mode restrictions)
+  }
+}
+
+export function clearNoteDraft({
+  githubRepo,
+  noteId,
+}: {
+  githubRepo: GitHubRepository | null
+  noteId: NoteId
+}) {
+  if (typeof window === "undefined" || !window.localStorage) return
+
+  try {
+    const key = getNoteStorageKey({ githubRepo, noteId })
+    // Cancel any pending debounced write for this key to avoid
+    // re-creating the draft after it's been cleared (e.g., after save)
+    const existingTimerId = draftWriteTimers.get(key)
+    if (existingTimerId !== undefined) {
+      window.clearTimeout(existingTimerId)
+      draftWriteTimers.delete(key)
+    }
+    window.localStorage.removeItem(key)
+  } catch {
+    // Ignore storage errors (e.g., private mode restrictions)
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft-aware previews and editor: shows resolved draft content, draft-derived frontmatter (font, tags), gist indicator, and a visible Draft indicator.
  * Per-note draft persistence in-browser with centralized draft save/discard/clear utilities and a Draft indicator component.

* **Improvements**
  * Editor flow unified around isDraft — save/discard flows, UI indicators, commands and focus updated.
  * Tooltip delay increased; icons explicitly marked decorative for assistive tech.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->