### PR TITLE
Change read/write toggle shortcut to Cmd+E

### DIFF
--- a/src/components/cheatsheet-dialog.tsx
+++ b/src/components/cheatsheet-dialog.tsx
@@ -63,7 +63,7 @@ export function CheatsheetDialog() {
         <CheatsheetSection title="Note shortcuts">
           <CheatsheetItem>
             <span>Toggle read/write mode</span>
-            <Keys keys={["⌥", "⇥"]} />
+            <Keys keys={["⌘", "E"]} />
           </CheatsheetItem>
           <CheatsheetItem>
             <span>Save note</span>

--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -132,7 +132,7 @@ function RouteComponent() {
   )
 }
 
-const toggleModeShortcut = ["⌥", "⇥"]
+const toggleModeShortcut = ["⌘", "E"]
 
 function renderTemplate(template: Template, args: Record<string, unknown> = {}) {
   let text = ejs.render(template.body, args)
@@ -420,7 +420,7 @@ function NotePage() {
 
   // Keyboard shortcuts
   useHotkeys(
-    "alt+tab",
+    "mod+e",
     (event) => {
       toggleMode()
       event.preventDefault()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated the keyboard shortcut to toggle read/write mode to Cmd+E on macOS and Ctrl+E on Windows/Linux.
  - Replaced the previous Alt+Tab binding with Mod+E across the note editor.
  - Updated the shortcuts cheat sheet to display the new shortcut (⌘E on macOS, Ctrl+E on Windows/Linux).
  - Ensures consistent shortcut behavior and labeling throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->