### PR TITLE
Fix property key height

### DIFF
--- a/src/components/property-key.tsx
+++ b/src/components/property-key.tsx
@@ -19,11 +19,11 @@ export function PropertyKeyEditor({ name, onChange }: PropertyKeyEditorProps) {
   )
 
   return (
-    <div className="truncate font-mono leading-[1.75]">
+    <div className="truncate font-mono leading-7">
       {mode === "read" ? (
         <button
           ref={buttonRef}
-          className="text-text-secondary truncate focus-ring py-1 px-2 coarse:px-3 coarse:py-2 hover:ring-inset hover:ring-1 cursor-text hover:ring-border w-full text-left rounded"
+          className="text-text-secondary truncate focus-ring py-0.5 px-2 coarse:px-3 coarse:py-1.5 hover:ring-inset hover:ring-1 cursor-text hover:ring-border w-full text-left rounded"
           onMouseDown={stopPropagationOnDoubleClick}
           onClick={() => setMode("write")}
           onFocus={() => setMode("write")}
@@ -37,7 +37,7 @@ export function PropertyKeyEditor({ name, onChange }: PropertyKeyEditorProps) {
           autoFocus
           type="text"
           defaultValue={name}
-          className="w-full rounded px-2 py-1 bg-transparent coarse:px-3 coarse:py-2 outline-none ring-2 ring-inset ring-border-focus"
+          className="w-full rounded px-2 py-0.5 bg-transparent coarse:px-3 coarse:py-1.5 outline-none ring-2 ring-inset ring-border-focus"
           autoCapitalize="off"
           autoCorrect="off"
           spellCheck="false"

--- a/src/components/property-value.tsx
+++ b/src/components/property-value.tsx
@@ -329,7 +329,7 @@ export function PropertyValueEditor({
             ref={buttonRef}
             role="button"
             tabIndex={0}
-            className="leading-[1.75] focus-ring hover:ring-inset hover:ring-1 cursor-text hover:ring-border px-2 py-1 coarse:px-3 coarse:py-2 w-full text-left rounded"
+            className="leading-7 focus-ring hover:ring-inset hover:ring-1 cursor-text hover:ring-border px-2 py-0.5 coarse:px-3 coarse:py-1.5 w-full text-left rounded"
             onMouseDown={stopPropagationOnDoubleClick}
             onPointerDown={handleButtonPointerDown}
             onClick={handleButtonClick}
@@ -365,7 +365,7 @@ export function PropertyValueEditor({
               placeholder=""
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={true}
-              className="px-2 py-1 coarse:px-3 coarse:py-2"
+              className="px-2 py-0.5 coarse:px-3 coarse:py-1.5"
               indentWithTab={false}
               onChange={onChange}
             />
@@ -376,7 +376,7 @@ export function PropertyValueEditor({
   }
 
   return (
-    <div className="px-2 py-1 coarse:px-3 coarse:py-2 leading-[1.75]">
+    <div className="px-2 py-0.5 coarse:px-3 coarse:py-1.5 leading-7">
       <PropertyValue property={[key, value]} />
     </div>
   )

--- a/src/styles/codemirror.css
+++ b/src/styles/codemirror.css
@@ -14,6 +14,7 @@
   white-space: pre-wrap;
   word-break: break-word;
   flex-shrink: 1;
+  line-height: 28px;
 }
 
 .cm-editor .cm-line {
@@ -22,7 +23,6 @@
 }
 
 .cm-editor .cm-scroller {
-  @apply leading-[1.75];
   font-family: unset;
   overflow: hidden;
 }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,6 +1,6 @@
 .markdown {
   font-size: var(--font-size-base);
-  line-height: 1.75;
+  line-height: 28px;
 }
 
 .markdown *:first-child {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized line-height across property keys/values, markdown, and code to a consistent 28px for more uniform text spacing.
  * Reduced vertical padding in viewing and editing states for tighter, more consistent layout.
  * No behavioral or API changes; interactions, modes, and public component signatures remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->