### PR TITLE
Adjust infinite scroll threshold for notes

### DIFF
--- a/src/components/note-list.tsx
+++ b/src/components/note-list.tsx
@@ -44,7 +44,9 @@ export function NoteList({
 
   const [numVisibleNotes, setNumVisibleNotes] = useState(initialVisibleNotes)
 
-  const [bottomRef, bottomInView] = useInView()
+  const [bottomRef, bottomInView] = useInView({
+    rootMargin: "0px 0px 400px 0px",
+  })
 
   const loadMore = React.useCallback(() => {
     setNumVisibleNotes((num) => Math.min(num + 10, searchResults.length))


### PR DESCRIPTION
## Summary
- trigger note list pagination when the load-more button is within 400px of view to smooth scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff8cd42e648321a12035733fd9054a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the timing of when additional notes are loaded while scrolling through your note list. Notes now load earlier in the scrolling process, providing a smoother continuous browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->