### PR TITLE
Add @ trigger for note wikilink autocomplete

### DIFF
--- a/src/components/note-editor.tsx
+++ b/src/components/note-editor.tsx
@@ -435,6 +435,7 @@ function insertWikilink({ view, from, to, noteId, label }: InsertWikilinkParams)
   const text = `[[${noteId}|${label}]]`
 
   const hasClosingBrackets = view.state.sliceDoc(to, to + 2) === "]]"
+
   view.dispatch({
     changes: { from, to: hasClosingBrackets ? to + 2 : to, insert: text },
     selection: { anchor: from + text.length },


### PR DESCRIPTION
## Summary
- allow the note autocomplete to activate when typing `@` in addition to `[[`
- reuse a shared wikilink insertion helper so both triggers insert the same wiki link syntax

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6901d78d0ec88321b8ff048663bf8c44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Note completion now recognizes @mentions in addition to [[wiki links]].

* **Improvements**
  * Unified link insertion so creating or selecting notes behaves consistently.
  * Cursor reliably placed after inserted links for smoother editing.
  * Query extraction improved to better detect whether the trigger was @ or a wikilink.
  * Inline insertion logic consolidated to ensure consistent bracket handling and insertion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->