### PR TITLE
Revert note autocomplete regex

### DIFF
--- a/src/components/note-editor.tsx
+++ b/src/components/note-editor.tsx
@@ -369,14 +369,13 @@ function useNoteCompletion() {
 
   const noteCompletion = React.useCallback(
     async (context: CompletionContext): Promise<CompletionResult | null> => {
-      const word = context.matchBefore(/(?:\[\[|@)[^\]|^|]*/)
+      const word = context.matchBefore(/\[\[[^\]|^|]*/)
 
       if (!word) {
         return null
       }
 
-      const triggerLength = word.text.startsWith("@") ? 1 : 2
-      const query = word.text.slice(triggerLength)
+      const query = word.text.slice(2)
 
       const searchResults = searchNotes(query)
 


### PR DESCRIPTION
Restore the note autocomplete regex to match only wikilinks.

No tests were run (not requested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts note autocomplete to wikilinks by removing the @ trigger and simplifying query parsing.
> 
> - **Editor Autocomplete**:
>   - **Note completion**: Match only wikilinks using `\[\[[^\]|^|]*`; remove `@` support and compute query via `slice(2)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 490f1de2db61097e25090bfcb363c8fd9e008964. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Note autocomplete now exclusively activates with the `[[` syntax. Support for alternative trigger methods has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->