### PR TITLE
Consolidate calendar navigation into single active link

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -11,11 +11,10 @@ import { githubRepoAtom, notesAtom, pinnedNotesAtom, tagSearcherAtom } from "../
 import { useNoteById, useSaveNote } from "../hooks/note"
 import { useSearchNotes } from "../hooks/search"
 import { Note } from "../schema"
-import { formatDate, formatDateDistance, toDateString, toWeekString } from "../utils/date"
+import { formatDate, formatDateDistance, toDateString } from "../utils/date"
 import { pluralize } from "../utils/pluralize"
 import {
   CalendarDateIcon16,
-  CalendarIcon16,
   CopyIcon16,
   ExternalLinkIcon16,
   GlobeIcon16,
@@ -32,7 +31,6 @@ import { NoteFavicon } from "./note-favicon"
 export const isCommandMenuOpenAtom = atom(false)
 
 const hasDailyNoteAtom = selectAtom(notesAtom, (notes) => notes.has(toDateString(new Date())))
-const hasWeeklyNoteAtom = selectAtom(notesAtom, (notes) => notes.has(toWeekString(new Date())))
 
 export function CommandMenu() {
   const navigate = useNavigate()
@@ -42,7 +40,6 @@ export function CommandMenu() {
   const saveNote = useSaveNote()
   const pinnedNotes = useAtomValue(pinnedNotesAtom)
   const getHasDailyNote = useAtomCallback(useCallback((get) => get(hasDailyNoteAtom), []))
-  const getHasWeeklyNote = useAtomCallback(useCallback((get) => get(hasWeeklyNoteAtom), []))
   const [isOpen, setIsOpen] = useAtom(isCommandMenuOpenAtom)
 
   // Get the current note if we're on a note page.
@@ -111,7 +108,7 @@ export function CommandMenu() {
         },
       },
       {
-        label: "Today",
+        label: "Calendar",
         icon: <CalendarDateIcon16 date={new Date().getDate()} />,
         onSelect: () => {
           navigate({
@@ -121,23 +118,6 @@ export function CommandMenu() {
             },
             search: {
               mode: getHasDailyNote() ? "read" : "write",
-              query: undefined,
-              view: "grid",
-            },
-          })
-        },
-      },
-      {
-        label: "This week",
-        icon: <CalendarIcon16 />,
-        onSelect: () => {
-          navigate({
-            to: "/notes/$",
-            params: {
-              _splat: toWeekString(new Date()),
-            },
-            search: {
-              mode: getHasWeeklyNote() ? "read" : "write",
               query: undefined,
               view: "grid",
             },
@@ -168,7 +148,7 @@ export function CommandMenu() {
         },
       },
     ]
-  }, [navigate, getHasDailyNote, getHasWeeklyNote])
+  }, [navigate, getHasDailyNote])
 
   const filteredNavItems = useMemo(() => {
     return navItems.filter((item) => {


### PR DESCRIPTION
## Summary
- Combine "Today" and "This week" nav items into a single "Calendar" link
- Calendar link now shows as active when viewing any daily or weekly note
- Uses custom active state detection via `useLocation` hook

## Approach
Validates current pathname against date and week string patterns to determine if the Calendar link should appear active, eliminating the need for separate nav items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Combine “Today” and “This week” into a single “Calendar” link that stays active on any daily or weekly note, and update the command menu accordingly.
> 
> - **Navigation**:
>   - Replace separate `Today`/`This week` items with a single `Calendar` link in `src/components/nav-items.tsx`.
>   - Determine active state via `useLocation` + `isValidDateString`/`isValidWeekString`; pass `forceActive` to `NavLink` and set `aria-current`.
>   - Remove weekly note logic/icons and related imports/atoms.
> - **Command Menu** (`src/components/command-menu.tsx`):
>   - Rename `Today` jump to `Calendar`; remove weekly option.
>   - Drop `toWeekString` usage and `hasWeeklyNote` atom; adjust dependencies.
> - **Components**:
>   - Enhance `NavLink` to support `forceActive` prop and conditional `aria-current` rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d7527d47191cac5b55a947e016c12149d0d2369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * "Today" command in the command menu replaced with "Calendar."
  * "This week" command removed from available options.
  * Calendar navigation simplified to a single unified entry for improved usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->