### PR TITLE
Auto-update note editor on external sync

### DIFF
--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -967,6 +967,20 @@ function useEditorValue({
     return getNoteDraft({ githubRepo, noteId }) ?? note?.content ?? defaultValue
   })
 
+  // Track previous note content to detect external changes
+  const [prevNoteContent, setPrevNoteContent] = useState(note?.content)
+
+  // Adjust state during render when note content changes externally (no effect needed)
+  // See: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (note?.content !== prevNoteContent) {
+    setPrevNoteContent(note?.content)
+    // Only update editor if there's no local draft
+    const hasDraft = getNoteDraft({ githubRepo, noteId }) !== null
+    if (!hasDraft && note?.content !== undefined) {
+      _setEditorValue(note.content)
+    }
+  }
+
   const isDraft = useMemo(() => {
     return editorValue !== (note ? note.content : defaultValue)
   }, [note, editorValue, defaultValue])


### PR DESCRIPTION
## Summary

Auto-update the note editor when external syncs occur without a local draft. Fixes the bug where synced changes show as a "dirty" state requiring discard to see updated content.

Uses React's render-time state adjustment pattern instead of effects for efficiency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the editor would not properly sync external note updates when no local draft changes existed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->