### PR TITLE
Make autocomplete menu background opaque

### DIFF
--- a/src/styles/codemirror.css
+++ b/src/styles/codemirror.css
@@ -55,7 +55,7 @@
 }
 
 .cm-editor .cm-tooltip.cm-tooltip-autocomplete {
-  @apply card-2 max-w-sm border-0 p-1;
+  @apply card-2 max-w-sm border-0 !bg-bg-overlay p-1 !backdrop-blur-none;
 }
 
 .cm-editor .cm-tooltip.cm-tooltip-autocomplete > ul {


### PR DESCRIPTION
## Summary
- Override card-2's translucent background with solid bg-bg-overlay color
- Remove backdrop blur effect from autocomplete tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated autocomplete tooltip styling with overlay background and backdrop adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->