### PR TITLE
Extract new note creation logic into reusable hook

### DIFF
--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,7 +1,8 @@
-import { useNavigate, useRouter } from "@tanstack/react-router"
+import { useRouter } from "@tanstack/react-router"
 import { useAtom } from "jotai"
 import { useHotkeys } from "react-hotkeys-hook"
 import { sidebarAtom } from "../global-state"
+import { useCreateNewNote } from "../hooks/create-new-note"
 import { cx } from "../utils/cx"
 import { IconButton } from "./icon-button"
 import { ArrowLeftIcon16, ArrowRightIcon16, SidebarCollapsedIcon16 } from "./icons"
@@ -16,8 +17,8 @@ export type AppHeaderProps = {
 
 export function AppHeader({ title, icon, className, actions }: AppHeaderProps) {
   const router = useRouter()
-  const navigate = useNavigate()
   const [sidebar, setSidebar] = useAtom(sidebarAtom)
+  const createNewNote = useCreateNewNote()
 
   // Toggle sidebar with Cmd/Ctrl + B
   useHotkeys(
@@ -32,25 +33,11 @@ export function AppHeader({ title, icon, className, actions }: AppHeaderProps) {
     },
   )
 
-  useHotkeys(
-    "mod+shift+o",
-    () => {
-      navigate({
-        to: "/notes/$",
-        params: { _splat: `${Date.now()}` },
-        search: {
-          mode: "write",
-          query: undefined,
-          view: "grid",
-        },
-      })
-    },
-    {
-      preventDefault: true,
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-    },
-  )
+  useHotkeys("mod+shift+o", createNewNote, {
+    preventDefault: true,
+    enableOnFormTags: true,
+    enableOnContentEditable: true,
+  })
 
   return (
     <div className={cx("@container/header", className)}>

--- a/src/components/new-note-button.tsx
+++ b/src/components/new-note-button.tsx
@@ -1,56 +1,16 @@
-import { useLocation, useMatch, useNavigate } from "@tanstack/react-router"
-import { parseQuery } from "../utils/search"
+import { useCreateNewNote } from "../hooks/create-new-note"
 import { IconButton } from "./icon-button"
 import { PlusIcon16 } from "./icons"
 
-function useTagsFromRoute() {
-  const tags = new Set<string>()
-
-  const tagMatch = useMatch({ from: "/_appRoot/tags_/$", shouldThrow: false })
-  if (tagMatch?.params._splat) {
-    tags.add(tagMatch.params._splat)
-  }
-
-  const location = useLocation()
-  const query = location.search.query ?? ""
-  const tagFilters = parseQuery(query).filters.filter((q) => q.key === "tag" && !q.exclude)
-
-  tagFilters.forEach((filter) => {
-    filter.values.forEach((tag) => tags.add(tag))
-  })
-
-  return Array.from(tags)
-}
-
 export function NewNoteButton() {
-  const navigate = useNavigate()
-  const tags = useTagsFromRoute()
+  const createNewNote = useCreateNewNote()
 
   return (
     <IconButton
       aria-label="New note"
       shortcut={["⌘", "⇧", "O"]}
       size="small"
-      onClick={() => {
-        const noteId = `${Date.now()}`
-
-        // Add tags to the note
-        let content = ""
-        if (tags.length > 0) {
-          content = `---\ntags: [${tags.join(", ")}]\n---\n\n`
-        }
-
-        navigate({
-          to: "/notes/$",
-          params: { _splat: noteId },
-          search: {
-            mode: "write",
-            query: undefined,
-            view: "grid",
-            content,
-          },
-        })
-      }}
+      onClick={createNewNote}
     >
       <PlusIcon16 />
     </IconButton>

--- a/src/hooks/create-new-note.ts
+++ b/src/hooks/create-new-note.ts
@@ -1,0 +1,48 @@
+import { useLocation, useMatch, useNavigate } from "@tanstack/react-router"
+import { useCallback } from "react"
+import { parseQuery } from "../utils/search"
+
+function useTagsFromRoute() {
+  const tags = new Set<string>()
+
+  const tagMatch = useMatch({ from: "/_appRoot/tags_/$", shouldThrow: false })
+  if (tagMatch?.params._splat) {
+    tags.add(tagMatch.params._splat)
+  }
+
+  const location = useLocation()
+  const query = location.search.query ?? ""
+  const tagFilters = parseQuery(query).filters.filter((q) => q.key === "tag" && !q.exclude)
+
+  tagFilters.forEach((filter) => {
+    filter.values.forEach((tag) => tags.add(tag))
+  })
+
+  return Array.from(tags)
+}
+
+export function useCreateNewNote() {
+  const navigate = useNavigate()
+  const tags = useTagsFromRoute()
+
+  return useCallback(() => {
+    const noteId = `${Date.now()}`
+
+    // Add tags to the note
+    let content = ""
+    if (tags.length > 0) {
+      content = `---\ntags: [${tags.join(", ")}]\n---\n\n`
+    }
+
+    navigate({
+      to: "/notes/$",
+      params: { _splat: noteId },
+      search: {
+        mode: "write",
+        query: undefined,
+        view: "grid",
+        content: content || undefined,
+      },
+    })
+  }, [navigate, tags])
+}


### PR DESCRIPTION
## Summary

- Share note-creation logic between NewNoteButton and mod+shift+o hotkey via `useCreateNewNote` hook
- Ensures both paths apply tag frontmatter from route/query consistently
- Reduces duplication and prevents behavior divergence

## Test plan

- [ ] Create note from NewNoteButton button and verify tags applied
- [ ] Create note with mod+shift+o hotkey and verify tags applied
- [ ] Verify both paths create identical notes with same tag frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)