### PR TITLE
Reduce large markdown font size to 15px

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -119,8 +119,8 @@ export const Markdown = React.memo(
                 style={
                   fontSize === "large"
                     ? ({
-                        "--font-size-base": "16px",
-                        "--font-size-sm": "14px",
+                        "--font-size-base": "15px",
+                        "--font-size-sm": "13px",
                       } as React.CSSProperties)
                     : undefined
                 }
@@ -182,8 +182,8 @@ export const Markdown = React.memo(
                   style={
                     fontSize === "large"
                       ? ({
-                          "--font-size-base": "16px",
-                          "--font-size-sm": "14px",
+                          "--font-size-base": "15px",
+                          "--font-size-sm": "13px",
                         } as React.CSSProperties)
                       : undefined
                   }


### PR DESCRIPTION
Reduces the large font size setting for markdown from 16px/14px to 15px/13px for improved readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted typography rendering for large text sizes with refined proportions for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->