### PR TITLE
Change hideDate prop to accept date string

### DIFF
--- a/src/components/task-item.tsx
+++ b/src/components/task-item.tsx
@@ -11,7 +11,7 @@ import { NoteLink } from "./note-link"
 type TaskItemProps = {
   task: Task
   parentId: NoteId
-  hideDate?: boolean
+  hideDate?: string
   className?: string
   onCompletedChange: (completed: boolean) => void
   onTextChange?: (text: string) => void
@@ -20,16 +20,17 @@ type TaskItemProps = {
 export function TaskItem({
   task,
   parentId,
-  hideDate = false,
+  hideDate,
   className,
   onCompletedChange,
   onTextChange,
 }: TaskItemProps) {
   const parentNote = useNoteById(parentId)
   const parentLabel = parentNote?.displayName ?? parentId
+  const shouldHideDate = hideDate !== undefined && hideDate === task.date
   const displayText = useMemo(
-    () => (hideDate ? removeDateFromTaskText(task.text, task.date) : task.text),
-    [hideDate, task.text, task.date],
+    () => (shouldHideDate ? removeDateFromTaskText(task.text, task.date) : task.text),
+    [shouldHideDate, task.text, task.date],
   )
   const [mode, setMode] = useState<"read" | "write">("read")
   const [pendingText, setPendingText] = useState(task.text)

--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -898,7 +898,7 @@ function NotePage() {
                           key={`${task.parentId}-${task.startOffset}`}
                           task={task}
                           parentId={task.parentId}
-                          hideDate={isDailyNote}
+                          hideDate={isDailyNote ? noteId : undefined}
                           onCompletedChange={(completed) => {
                             if (!parentNote) return
 


### PR DESCRIPTION
Change hideDate prop from boolean to date string that matches against task.date for selective date hiding. Only removes the date from display text when the provided date matches the task's date property.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the date display logic for task items to more accurately determine when dates should be shown or hidden in daily notes and backlinks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->