### PR TITLE
Make calendar navigation increment by day on daily pages

### DIFF
--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -40,6 +40,8 @@ export function Calendar({
   const searchParams = useSearch({ strict: false })
   const date = parseISO(activeNoteId)
 
+  const isWeeklyNote = isValidWeekString(activeNoteId)
+
   const startOfWeek = React.useMemo(() => (isMonday(date) ? date : previousMonday(date)), [date])
 
   const endOfWeek = React.useMemo(() => nextSunday(startOfWeek), [startOfWeek])
@@ -49,14 +51,14 @@ export function Calendar({
     [startOfWeek, endOfWeek],
   )
 
-  const navigateByWeek = React.useCallback(
+  const navigateByInterval = React.useCallback(
     (direction: "previous" | "next") => {
-      const isWeeklyNote = isValidWeekString(activeNoteId)
-      const weeksToAdd = direction === "next" ? 1 : -1
+      const increment = direction === "next" ? 1 : -1
 
+      // Navigate by week for weekly notes, by day for daily notes
       const target = isWeeklyNote
-        ? toWeekString(addWeeks(date, weeksToAdd))
-        : toDateString(addDays(date, weeksToAdd * 7))
+        ? toWeekString(addWeeks(date, increment))
+        : toDateString(addDays(date, increment))
 
       navigate({
         to: "/notes/$",
@@ -68,7 +70,7 @@ export function Calendar({
         },
       })
     },
-    [activeNoteId, date, navigate, searchParams.mode, searchParams.view],
+    [isWeeklyNote, date, navigate, searchParams.mode, searchParams.view],
   )
 
   return (
@@ -80,7 +82,10 @@ export function Calendar({
             <span>{startOfWeek.getFullYear()}</span>
           </span>
           <div className="flex gap-px rounded bg-bg-secondary">
-            <IconButton aria-label="Previous week" onClick={() => navigateByWeek("previous")}>
+            <IconButton
+              aria-label={isWeeklyNote ? "Previous week" : "Previous day"}
+              onClick={() => navigateByInterval("previous")}
+            >
               <ChevronLeftIcon16 />
             </IconButton>
             <Button
@@ -100,7 +105,10 @@ export function Calendar({
             >
               Today
             </Button>
-            <IconButton aria-label="Next week" onClick={() => navigateByWeek("next")}>
+            <IconButton
+              aria-label={isWeeklyNote ? "Next week" : "Next day"}
+              onClick={() => navigateByInterval("next")}
+            >
               <ChevronRightIcon16 />
             </IconButton>
           </div>


### PR DESCRIPTION
When viewing a daily note, the previous/next buttons now navigate to the previous/next day instead of skipping to the same day on the previous/next week. Weekly pages still navigate by week. Aria labels are also updated to reflect the increment type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Calendar prev/next now step by day on daily notes and by week on weekly notes, with dynamic aria labels.
> 
> - **Calendar (`src/components/calendar.tsx`)**:
>   - **Navigation logic**: Introduce `isWeeklyNote` and replace `navigateByWeek` with `navigateByInterval` to increment by day for daily notes and by week for weekly notes.
>   - **Controls**: Update prev/next buttons to use `navigateByInterval` and set aria labels to "Previous/Next day" or "Previous/Next week" accordingly.
>   - **Hooks**: Adjust `useCallback` dependencies to include `isWeeklyNote`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b21fa0c3a62bc207a4a18942656217accd923fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for both weekly and daily calendar navigation based on active note type.

* **Improvements**
  * Enhanced accessibility with contextual labels for navigation controls ("Previous/Next week" or "Previous/Next day").
  * Optimized navigation callback efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->