### PR TITLE
Fix dropdown menu alignment and font selector styling

### DIFF
--- a/src/components/task-item.tsx
+++ b/src/components/task-item.tsx
@@ -190,7 +190,7 @@ export function TaskItem({
               <MoreIcon16 />
             </IconButton>
           </DropdownMenu.Trigger>
-          <DropdownMenu.Content align="end" width={280}>
+          <DropdownMenu.Content align="end" width={280} alignOffset={-4}>
             <DropdownMenu.Label>Reschedule</DropdownMenu.Label>
             {(() => {
               const today = new Date()

--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -664,7 +664,7 @@ function NotePage() {
                   onSelect={() => updateFont(null)}
                 >
                   Default{" "}
-                  <span className="italic text-text-secondary eink:text-current">
+                  <span className="text-text-secondary eink:text-current">
                     ({fontDisplayNames[defaultFont]})
                   </span>
                 </DropdownMenu.Item>


### PR DESCRIPTION
Adjust reschedule dropdown offset for better alignment and remove italic styling from default font label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the horizontal alignment of the reschedule menu dropdown.
  * Changed the font styling in the Default font dropdown item from italic to regular text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->