### PR TITLE
Fix dropdown menu alignment in task items

### DIFF
--- a/src/components/task-item.tsx
+++ b/src/components/task-item.tsx
@@ -184,13 +184,13 @@ export function TaskItem({
         ) : null}
       </div>
       {mode === "read" ? (
-        <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+        <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen} modal={false}>
           <DropdownMenu.Trigger asChild>
             <IconButton aria-label="More actions" disableTooltip className="ml-1">
               <MoreIcon16 />
             </IconButton>
           </DropdownMenu.Trigger>
-          <DropdownMenu.Content align="end" width={280} alignOffset={-4}>
+          <DropdownMenu.Content align="end" width={280}>
             <DropdownMenu.Label>Reschedule</DropdownMenu.Label>
             {(() => {
               const today = new Date()


### PR DESCRIPTION
Remove alignOffset override to use default alignment and add modal=false to prevent backdrop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dropdown menu behavior in task items to use non-modal interaction in read mode for improved usability
  * Simplified dropdown content alignment settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->