### PR TITLE
Prevent parent note link text overflow in task items

### DIFF
--- a/src/components/task-item.tsx
+++ b/src/components/task-item.tsx
@@ -173,7 +173,7 @@ export function TaskItem({
           </div>
         )}
         {mode === "read" ? (
-          <div className="@md:h-7 h-6 flex items-center text-text-secondary">
+          <div className="@md:h-7 h-6 flex items-center text-text-secondary truncate">
             <NoteLink
               id={parentId}
               text={parentLabel}


### PR DESCRIPTION
Adds `truncate` class to parent note link in task items to prevent text overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text truncation for parent labels in task items, preventing text overflow and enhancing visual presentation in read mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->