### PR TITLE
Rename width option from 'fill' to 'full'

### DIFF
--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -695,13 +695,13 @@ function NotePage() {
                     </DropdownMenu.Item>
                     <DropdownMenu.Item
                       icon={<WidthFullIcon16 />}
-                      selected={resolvedWidth === "fill"}
+                      selected={resolvedWidth === "full"}
                       onSelect={() => {
-                        updateWidth("fill")
+                        updateWidth("full")
                         editorRef.current?.view?.focus()
                       }}
                     >
-                      Fill
+                      Full
                     </DropdownMenu.Item>
                     <DropdownMenu.Separator />
                   </>

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -86,6 +86,6 @@ export const fontSchema = z.enum(["sans", "serif", "handwriting"])
 
 export type Font = z.infer<typeof fontSchema>
 
-export const widthSchema = z.enum(["fixed", "fill"])
+export const widthSchema = z.enum(["fixed", "full"])
 
 export type Width = z.infer<typeof widthSchema>


### PR DESCRIPTION
Updated the width schema enum and UI to use "full" instead of "fill" for improved terminology clarity on the note page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated note editor width option label from "Fill" to "Full" with corresponding internal value changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->