### PR TITLE
Rename taskQuery param to tasks and exclude current note from backlink tasks

### DIFF
--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -83,7 +83,7 @@ type RouteSearch = {
   mode: "read" | "write"
   query: string | undefined
   view: "grid" | "list"
-  taskQuery?: string | undefined
+  tasks?: string | undefined
   content?: string
 }
 
@@ -93,7 +93,7 @@ export const Route = createFileRoute("/_appRoot/notes_/$")({
       mode: search.mode === "write" ? "write" : "read",
       query: typeof search.query === "string" ? search.query : undefined,
       view: search.view === "list" ? "list" : "grid",
-      taskQuery: typeof search.taskQuery === "string" ? search.taskQuery : undefined,
+      tasks: typeof search.tasks === "string" ? search.tasks : undefined,
       content: typeof search.content === "string" ? search.content : undefined,
     }
   },
@@ -154,7 +154,7 @@ const fontDisplayNames: Record<Font, string> = {
 function NotePage() {
   // Router
   const { _splat: noteId } = Route.useParams()
-  const { mode, query, view, taskQuery, content: defaultContent } = Route.useSearch()
+  const { mode, query, view, tasks, content: defaultContent } = Route.useSearch()
   const navigate = Route.useNavigate()
 
   // Global state
@@ -177,8 +177,9 @@ function NotePage() {
     return new Map<NoteId, Note>(notes.map((note) => [note.id, note]))
   }, [noteId, searchNotes])
   const backlinkTasks = React.useMemo(() => {
-    return searchTasks(`link:"${noteId}"`)
+    return searchTasks(`link:"${noteId}" -note:"${noteId}"`)
   }, [noteId, searchTasks])
+
   // Editor state
   const editorRef = React.useRef<ReactCodeMirrorRef>(null)
   const { editorValue, setEditorValue, isDraft, discardChanges } = useEditorValue({
@@ -891,11 +892,11 @@ function NotePage() {
                 <Details.Summary>Tasks</Details.Summary>
                 <LinkHighlightProvider href={`/notes/${noteId}`}>
                   <TaskList
-                    baseQuery={`link:"${noteId}"`}
-                    query={taskQuery ?? ""}
-                    onQueryChange={(taskQuery) =>
+                    baseQuery={`link:"${noteId}" -note:"${noteId}"`}
+                    query={tasks ?? ""}
+                    onQueryChange={(tasks) =>
                       navigate({
-                        search: (prev) => ({ ...prev, taskQuery }),
+                        search: (prev) => ({ ...prev, tasks }),
                         replace: true,
                       })
                     }


### PR DESCRIPTION
## Summary
- Renames the two-word `taskQuery` search param to `tasks` for consistency with other params
- Excludes the current note from backlink tasks query so tasks in the current note aren't duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal parameter naming conventions for task queries in note routes.

* **Bug Fixes**
  * Fixed backlink task queries to properly exclude the current note from results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->