### PR TITLE
Add GitHub user id to auth metadata

### DIFF
--- a/netlify/edge-functions/github-auth.ts
+++ b/netlify/edge-functions/github-auth.ts
@@ -29,10 +29,13 @@ export default async (request: Request) => {
       throw new Error(error)
     }
 
-    const { login, name, email } = await getUser(token)
+    const { id, login, name, email } = await getUser(token)
 
     const redirectUrl = new URL(state || "https://uselumen.com")
     redirectUrl.searchParams.set("user_token", token)
+    if (typeof id === "number" && Number.isFinite(id)) {
+      redirectUrl.searchParams.set("user_id", String(id))
+    }
     redirectUrl.searchParams.set("user_login", login)
     redirectUrl.searchParams.set("user_name", name)
     redirectUrl.searchParams.set("user_email", email)
@@ -50,7 +53,7 @@ async function getUser(token: string) {
     },
   })
 
-  const { error, login, name } = await userResponse.json()
+  const { error, id, login, name } = await userResponse.json()
 
   if (error) {
     throw new Error(error)
@@ -83,7 +86,7 @@ async function getUser(token: string) {
     )
   }
 
-  return { login, name, email: primaryEmail.email }
+  return { id, login, name, email: primaryEmail.email }
 }
 
 export const config: Config = {

--- a/src/global-state.ts
+++ b/src/global-state.ts
@@ -295,22 +295,26 @@ function createGlobalStateMachine() {
       services: {
         resolveUser: async () => {
           // First, check URL params for user metadata
-          const token = new URLSearchParams(window.location.search).get("user_token")
-          const login = new URLSearchParams(window.location.search).get("user_login")
-          const name = new URLSearchParams(window.location.search).get("user_name")
-          const email = new URLSearchParams(window.location.search).get("user_email")
+          const searchParams = new URLSearchParams(window.location.search)
+          const token = searchParams.get("user_token")
+          const id = searchParams.get("user_id")
+          const login = searchParams.get("user_login")
+          const name = searchParams.get("user_name")
+          const email = searchParams.get("user_email")
 
           if (token && login && name && email) {
+            const idNumberRaw = id ? Number(id) : undefined
+            const idNumber = Number.isFinite(idNumberRaw) ? idNumberRaw : undefined
+
             // Save user metadata to localStorage
             localStorage.setItem(
               GITHUB_USER_STORAGE_KEY,
-              JSON.stringify({ token, login, name, email }),
+              JSON.stringify({ token, id: idNumber, login, name, email }),
             )
-
-            const searchParams = new URLSearchParams(window.location.search)
 
             // Remove user metadata from URL
             searchParams.delete("user_token")
+            searchParams.delete("user_id")
             searchParams.delete("user_login")
             searchParams.delete("user_name")
             searchParams.delete("user_email")
@@ -321,7 +325,7 @@ function createGlobalStateMachine() {
               }`,
             )
 
-            return { githubUser: { token, login, name, email } }
+            return { githubUser: { token, id: idNumber, login, name, email } }
           }
 
           // Next, check localStorage for user metadata

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -59,6 +59,7 @@ export type GitHubRepository = {
 
 export const githubUserSchema = z.object({
   token: z.string(),
+  id: z.number().optional(),
   login: z.string(),
   name: z.string(),
   email: z.string(),


### PR DESCRIPTION
Propagates GitHub user id through the auth redirect and local storage. Updates schema to allow the optional id field.