### PR TITLE
Fix Settings nav link text color when active

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -107,7 +107,7 @@ body:has([data-resizing="true"]) * {
 }
 
 .nav-item[aria-current] {
-  @apply bg-bg-secondary font-bold;
+  @apply bg-bg-secondary font-bold text-text;
   @apply eink:bg-text eink:text-bg;
 }
 


### PR DESCRIPTION
Fix the Settings nav link text color to match other active nav items when selected.

The Settings link now displays with the same text color as other active nav items in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)