### PR TITLE
Fix priority indicator styling in E-Ink mode

### DIFF
--- a/src/codemirror-extensions/priority.ts
+++ b/src/codemirror-extensions/priority.ts
@@ -1,10 +1,10 @@
 import { EditorState, Extension, Range, StateField, Transaction } from "@codemirror/state"
 import { Decoration, DecorationSet, EditorView } from "@codemirror/view"
 
-const priorityStyles: Record<1 | 2 | 3, string> = {
-  1: "color: var(--red-a12); background-color: var(--red-a4); border-radius: var(--border-radius-sm); padding: 0 2px;",
-  2: "color: var(--orange-a12); background-color: var(--orange-a4); border-radius: var(--border-radius-sm); padding: 0 2px;",
-  3: "color: var(--blue-a12); background-color: var(--blue-a4); border-radius: var(--border-radius-sm); padding: 0 2px;",
+const priorityClasses: Record<1 | 2 | 3, string> = {
+  1: "cm-priority cm-priority-1",
+  2: "cm-priority cm-priority-2",
+  3: "cm-priority cm-priority-3",
 }
 
 const priorityField = StateField.define({
@@ -33,7 +33,7 @@ function createDecorations(state: EditorState): DecorationSet {
 
     decorations.push(
       Decoration.mark({
-        attributes: { style: priorityStyles[level] },
+        class: priorityClasses[level],
       }).range(from, to),
     )
   }

--- a/src/components/priority-indicator.tsx
+++ b/src/components/priority-indicator.tsx
@@ -14,7 +14,7 @@ export function PriorityIndicator({ level }: PriorityIndicatorProps) {
   return (
     <span
       className={cx(
-        "rounded-sm px-0.5 leading-4 eink:text-text eink:bg-transparent",
+        "rounded-sm px-0.5 leading-4 eink:text-text eink:bg-transparent eink:px-0",
         colors[level],
       )}
     >

--- a/src/styles/codemirror.css
+++ b/src/styles/codemirror.css
@@ -119,3 +119,19 @@
 .cm-wikilinks-enabled .cm-editor .cm-wikilink:hover {
   @apply cursor-pointer decoration-solid ring-0;
 }
+
+.cm-editor .cm-priority {
+  @apply rounded-sm px-0.5 eink:bg-transparent eink:px-0 eink:text-text;
+}
+
+.cm-editor .cm-priority-1 {
+  @apply text-[var(--red-a12)] bg-[var(--red-a4)];
+}
+
+.cm-editor .cm-priority-2 {
+  @apply text-[var(--orange-a12)] bg-[var(--orange-a4)];
+}
+
+.cm-editor .cm-priority-3 {
+  @apply text-[var(--blue-a12)] bg-[var(--blue-a4)];
+}


### PR DESCRIPTION
## Summary
- Remove color and padding from priority indicators when in E-Ink mode
- Convert CodeMirror priority styles from inline to CSS classes for better E-Ink support
- Consolidate E-Ink overrides in base `.cm-priority` class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts priority marker styling from inline styles to CSS classes and centralizes E‑Ink overrides.
> 
> - Replace inline `Decoration.mark` styles with class names in `codemirror-extensions/priority.ts` using `cm-priority` and level-specific classes
> - Add `.cm-priority`, `.cm-priority-1/2/3` rules in `styles/codemirror.css` with E‑Ink-friendly overrides consolidated in the base class
> - Tweak `PriorityIndicator` span classes to remove padding in E‑Ink (`eink:px-0`) while preserving color classes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc6a9fcb2df4e478a353de3f1a4f0fa33eaf011d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->