### PR TITLE
Add 'Next week' task scheduling option and improve nav item styling

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router"
-import { addDays } from "date-fns"
+import { addDays, nextMonday } from "date-fns"
 import React from "react"
 import ReactMarkdown from "react-markdown"
 import { CodeProps, LiProps } from "react-markdown/lib/ast-to-react"
@@ -624,6 +624,17 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
         icon: <CalendarDateIcon16 date={tomorrow.getDate()} />,
         targetId: tomorrowId,
         trailingText: formatDate(tomorrowId),
+      })
+    }
+
+    const monday = nextMonday(now)
+    const mondayId = toDateString(monday)
+    if (noteId !== mondayId) {
+      options.push({
+        label: "Next week",
+        icon: <CalendarDateIcon16 date={monday.getDate()} />,
+        targetId: mondayId,
+        trailingText: formatDate(mondayId),
       })
     }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -99,7 +99,7 @@ body:has([data-resizing="true"]) * {
 /* Nav item */
 
 .nav-item {
-  @apply flex h-8 items-center gap-3 rounded px-2 coarse:h-10 coarse:gap-4 coarse:px-3;
+  @apply flex h-8 items-center gap-3 rounded px-2 cursor-pointer coarse:h-10 coarse:gap-4 coarse:px-3;
 }
 
 .nav-item:is(a, button) {


### PR DESCRIPTION
Add next Monday date quick-action to task scheduling menu and improve pointer feedback on navigation items.

🤖 Generated with Claude Code