### PR TITLE
Update list item transition to be background-color specific

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -667,7 +667,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
     <li
       {...props}
       className={cx(
-        "transition-colors rounded-lg",
+        "transition-[background-color] rounded-lg",
         isMenuOpen &&
           "bg-bg-selection epaper:bg-transparent epaper:ring-1 epaper:ring-border epaper:ring-inset",
         className,


### PR DESCRIPTION
Improved CSS specificity by changing the transition property from 'transition-colors' to 'transition-[background-color]' for the ListItem component.

This ensures only the background color transitions, making the animation more precise and performant.

🤖 Generated with Claude Code