### PR TITLE
Update draft indicator UX and accessibility

### DIFF
--- a/src/components/draft-indicator.tsx
+++ b/src/components/draft-indicator.tsx
@@ -3,7 +3,8 @@ import { DotIcon8 } from "./icons"
 
 export function DraftIndicator({ className }: { className?: string }) {
   return (
-    <div aria-label="Unsaved changes" className={cx("grid place-items-center size-4", className)}>
+    <div className={cx("grid place-items-center size-4", className)}>
+      <span className="sr-only">Unsaved changes</span>
       <DotIcon8 className="text-text-pending" />
     </div>
   )

--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -454,8 +454,35 @@ function NotePage() {
 
   return (
     <PageLayout
-      title={`${noteId}.md`}
-      icon={isDraft ? <DraftIndicator /> : <NoteFavicon note={parsedNote} />}
+      title={
+        <div className="flex items-center gap-1">
+          <span className="truncate">{noteId}.md</span>
+          {isDraft ? (
+            <DropdownMenu modal={false}>
+              <DropdownMenu.Trigger
+                render={
+                  <IconButton aria-label="Unsaved changes" size="small" className="px-1">
+                    <DraftIndicator />
+                  </IconButton>
+                }
+              />
+              <DropdownMenu.Content>
+                <DropdownMenu.Item
+                  icon={<UndoIcon16 />}
+                  variant="danger"
+                  onClick={() => {
+                    discardChanges()
+                    editorRef.current?.view?.focus()
+                  }}
+                >
+                  Discard changes
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          ) : null}
+        </div>
+      }
+      icon={<NoteFavicon note={parsedNote} />}
       actions={
         <div className="flex items-center gap-2">
           {(!note && editorValue) || isDraft ? (
@@ -537,21 +564,7 @@ function NotePage() {
                   </IconButton>
                 }
               />
-              <DropdownMenu.Content align="end" side="top">
-                {isDraft ? (
-                  <>
-                    <DropdownMenu.Item
-                      icon={<UndoIcon16 />}
-                      onClick={() => {
-                        discardChanges()
-                        editorRef.current?.view?.focus()
-                      }}
-                    >
-                      Discard changes
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Separator />
-                  </>
-                ) : null}
+              <DropdownMenu.Content align="end">
                 {containerWidth > 800 && (
                   <>
                     <DropdownMenu.Group>


### PR DESCRIPTION
Move draft indicator from page icon to title with dropdown menu for discarding unsaved changes. Improves accessibility by using sr-only text instead of aria-label. Consolidates draft-related actions into a more discoverable location in the page header.