### PR TITLE
Update dropdown group label styling for coarse pointer

### DIFF
--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -137,7 +137,7 @@ const GroupLabel = React.forwardRef<HTMLDivElement, Menu.GroupLabel.Props>(
     <Menu.GroupLabel
       ref={ref}
       className={cx(
-        "flex h-8 select-none items-center px-3 text-sm text-text-secondary coarse:pt-2",
+        "flex h-8 select-none items-center px-3 text-sm text-text-secondary coarse:h-9",
         className,
       )}
       {...props}


### PR DESCRIPTION
Updates the dropdown group label styling to improve touch device experience.

Changed the coarse pointer class from `pt-2` to `h-9` for better touch target sizing.

🤖 Generated with Claude Code