### PR TITLE
Support slashes in wikilink IDs

### DIFF
--- a/src/remark-plugins/wikilink.test.ts
+++ b/src/remark-plugins/wikilink.test.ts
@@ -81,6 +81,18 @@ runTests([
     input: `[[foo.bar]]`,
     output: `<p><wikilink id="foo.bar" text="" /></p>`,
   },
+  {
+    input: `[[foo/bar]]`,
+    output: `<p><wikilink id="foo/bar" text="" /></p>`,
+  },
+  {
+    input: `[[foo/bar|my link]]`,
+    output: `<p><wikilink id="foo/bar" text="my link" /></p>`,
+  },
+  {
+    input: `[[path/to/note]]`,
+    output: `<p><wikilink id="path/to/note" text="" /></p>`,
+  },
 
   // Invalid wikilinks
   {

--- a/src/remark-plugins/wikilink.ts
+++ b/src/remark-plugins/wikilink.ts
@@ -151,7 +151,8 @@ function isFilenameChar(code: Code): boolean {
     code === codes.atSign ||
     code === codes.leftCurlyBrace ||
     code === codes.rightCurlyBrace ||
-    code === codes.space
+    code === codes.space ||
+    code === codes.slash
   )
 }
 


### PR DESCRIPTION
## Summary

Allow forward slashes (/) in wikilink IDs so that wikilinks like `[[foo/bar|my link]]` correctly parse "foo/bar" as the ID and "my link" as the display text.

## Changes

- Added `/` to valid filename characters in remark wikilink parser
- Added test cases for wikilinks with slashes in various formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)