### PR TITLE
Disable preview cards on touch devices

### DIFF
--- a/src/components/note-hover-card.tsx
+++ b/src/components/note-hover-card.tsx
@@ -1,4 +1,6 @@
 import { PreviewCard } from "@base-ui/react/preview-card"
+import React from "react"
+import { useIsTouchDevice } from "../hooks/use-is-touch-device"
 import { Note } from "../schema"
 import { cx } from "../utils/cx"
 import { NotePreview } from "./note-preview"
@@ -67,6 +69,13 @@ function Trigger({
   payload: Payload
   children: React.ReactNode
 }) {
+  const isTouchDevice = useIsTouchDevice()
+
+  // On touch devices, skip the preview card and just render the link
+  if (isTouchDevice) {
+    return React.cloneElement(render, {}, children)
+  }
+
   return (
     <PreviewCard.Trigger<Payload> render={render} payload={payload}>
       {children}

--- a/src/hooks/use-is-touch-device.ts
+++ b/src/hooks/use-is-touch-device.ts
@@ -1,0 +1,25 @@
+import { useSyncExternalStore } from "react"
+
+function subscribe(callback: () => void) {
+  // Listen for changes to touch capability (though this rarely changes)
+  window.addEventListener("touchstart", callback, { once: true })
+  return () => {
+    window.removeEventListener("touchstart", callback)
+  }
+}
+
+function getSnapshot() {
+  return ("ontouchstart" in window) || navigator.maxTouchPoints > 0
+}
+
+function getServerSnapshot() {
+  return false
+}
+
+/**
+ * Hook to detect if the device has touch capabilities.
+ * Returns true for touch-capable devices (phones, tablets, touch laptops).
+ */
+export function useIsTouchDevice() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}


### PR DESCRIPTION
## Summary
- Adds touch detection hook using `('ontouchstart' in window) || navigator.maxTouchPoints > 0`
- Disables Base UI preview cards on touch-capable devices
- Preview cards now only appear on hover for mouse/trackpad users

## Test plan
- [ ] Test on desktop with mouse - preview cards should appear on hover
- [ ] Test on mobile device - preview cards should not appear, links should be directly tappable
- [ ] Test on touch laptop - preview cards should be disabled
- [ ] Verify all note links, date links, week links, and calendar items work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)