### PR TITLE
Hide PreviewCard on touch devices

### DIFF
--- a/src/components/note-hover-card.tsx
+++ b/src/components/note-hover-card.tsx
@@ -35,7 +35,7 @@ function Provider({
             >
               <PreviewCard.Popup
                 className={cx(
-                  "card-2 z-30 w-96 rounded-[calc(var(--border-radius-base)+6px)]! print:hidden coarse:hidden",
+                  "card-2 z-30 w-96 rounded-[calc(var(--border-radius-base)+6px)]! print:hidden no-hover:hidden",
                   "transition-[transform,scale,opacity] epaper:transition-none",
                   "data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
                   "data-[starting-style]:scale-95 data-[starting-style]:opacity-0",

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -10,6 +10,7 @@ module.exports = {
   theme: {
     extend: {
       screens: {
+        "no-hover": { raw: "(hover: none)" },
         coarse: { raw: "(pointer: coarse)" },
         fine: { raw: "(pointer: fine)" },
         "2x": { raw: "(min-resolution: 192dpi)" },


### PR DESCRIPTION
Hide the PreviewCard popup on touch devices by adding `coarse:hidden` class. This prevents the preview from appearing on mobile/tablet devices while maintaining the behavior on desktop.