### PR TITLE
Open GitHub auth in new tab when embedded

### DIFF
--- a/src/components/github-auth.tsx
+++ b/src/components/github-auth.tsx
@@ -23,11 +23,19 @@ export function SignInButton(props: ButtonProps) {
           return
         }
 
-        window.location.href = urlcat("https://github.com/login/oauth/authorize", {
+        const authUrl = urlcat("https://github.com/login/oauth/authorize", {
           client_id: import.meta.env.VITE_GITHUB_CLIENT_ID,
           state: window.location.href,
           scope: "repo,gist,user:email",
         })
+
+        // Open in new tab if in iframe (GitHub doesn't load inside iframes)
+        const isInIframe = window.self !== window.top
+        if (isInIframe) {
+          window.open(authUrl, "_blank", "noopener")
+        } else {
+          window.location.href = authUrl
+        }
 
         props.onClick?.(event)
       }}

--- a/src/components/sign-in-banner.tsx
+++ b/src/components/sign-in-banner.tsx
@@ -12,8 +12,8 @@ export function SignInBanner() {
   return (
     <div className="flex shrink-0 flex-col justify-between gap-3 border-b border-border-secondary p-4 text-text sm:flex-row sm:items-center sm:p-2 print:hidden">
       <span className="sm:px-2">
-        Lumen is in <span className="italic">read-only</span> mode.
-        <span className="hidden md:inline"> Sign in to start writing notes.</span>
+        Lumen is in demo mode.
+        <span className="hidden md:inline"> Sign in to write your own notes.</span>
       </span>
       <SignInButton />
     </div>


### PR DESCRIPTION
Open the GitHub OAuth flow in a new tab when running inside an iframe and update demo banner copy.