### PR TITLE
Hide sign-in banner for Lumen embeds

### DIFF
--- a/src/components/sign-in-banner.tsx
+++ b/src/components/sign-in-banner.tsx
@@ -11,8 +11,7 @@ export function SignInBanner() {
   if (isInIframe && document.referrer) {
     try {
       const referrerHost = new URL(document.referrer).hostname
-      isEmbeddedInLumen =
-        referrerHost === "uselumen.com" || referrerHost.endsWith(".uselumen.com")
+      isEmbeddedInLumen = referrerHost === "uselumen.com" || referrerHost.endsWith(".uselumen.com")
     } catch {
       // Ignore invalid referrer strings
     }


### PR DESCRIPTION
Hide the sign-in banner when the app is embedded in uselumen.com.\n\nThis detects iframe embedding and validates the referrer hostname for uselumen.com or subdomains.