### PR TITLE
fix: remove broken iframe check from sign-in banner

### DIFF
--- a/src/components/sign-in-banner.tsx
+++ b/src/components/sign-in-banner.tsx
@@ -5,19 +5,7 @@ import { isSignedOutAtom } from "../global-state"
 export function SignInBanner() {
   const isSignedOut = useAtomValue(isSignedOutAtom)
 
-  // Don't show sign-in banner when embedded in uselumen.com
-  const isInIframe = window.self !== window.top
-  let isEmbeddedInLumen = false
-  if (isInIframe && document.referrer) {
-    try {
-      const referrerHost = new URL(document.referrer).hostname
-      isEmbeddedInLumen = referrerHost === "uselumen.com" || referrerHost.endsWith(".uselumen.com")
-    } catch {
-      // Ignore invalid referrer strings
-    }
-  }
-
-  if (!isSignedOut || isEmbeddedInLumen) {
+  if (!isSignedOut) {
     return null
   }
 


### PR DESCRIPTION
The iframe/uselumen.com embed detection wasn't working correctly.

Removing it for now — can be revisited later if needed.

---
*Created by Goose 🪿*