### PR TITLE
fix: prevent code blocks from causing horizontal page scroll

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -59,6 +59,11 @@
   font-size: var(--font-size-lg);
 }
 
+.markdown .pre-container {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 .markdown pre {
   overflow: auto;
   border-radius: var(--border-radius-lg);


### PR DESCRIPTION
## Problem
Long code blocks in markdown were causing horizontal scroll on the entire page.

## Solution
Added `.pre-container` CSS class with:
- `max-width: 100%` - constrain to parent width
- `overflow-x: auto` - scroll internally when content overflows

This makes long code blocks scroll within their container instead of breaking the page layout.