### PR TITLE
Fix task reordering bug when note has no trailing newline

### DIFF
--- a/src/utils/reorder-list-item.test.ts
+++ b/src/utils/reorder-list-item.test.ts
@@ -200,6 +200,21 @@ describe("moveListItemUp", () => {
     const result = moveListItemUp(content, start, end)
     expect(result).toBeNull()
   })
+
+  it("handles content without trailing newline - move last up", () => {
+    // No trailing newline at end of content
+    const content = "- [ ] Task 1\n- [ ] Task 2"
+    // "- [ ] Task 2" starts at position 13
+    const result = moveListItemUp(content, 13, 25)
+    expect(result).toBe("- [ ] Task 2\n- [ ] Task 1")
+  })
+
+  it("handles three items without trailing newline - move last up", () => {
+    const content = "- [ ] Task 1\n- [ ] Task 2\n- [ ] Task 3"
+    // "- [ ] Task 3" starts at position 26
+    const result = moveListItemUp(content, 26, 38)
+    expect(result).toBe("- [ ] Task 1\n- [ ] Task 3\n- [ ] Task 2")
+  })
 })
 
 describe("moveListItemDown", () => {
@@ -284,5 +299,18 @@ describe("moveListItemDown", () => {
     const end = content.indexOf("\n", start)
     const result = moveListItemDown(content, start, end)
     expect(result).toBeNull()
+  })
+
+  it("handles content without trailing newline - move first down", () => {
+    // No trailing newline at end of content
+    const content = "- [ ] Task 1\n- [ ] Task 2"
+    const result = moveListItemDown(content, 0, 12)
+    expect(result).toBe("- [ ] Task 2\n- [ ] Task 1")
+  })
+
+  it("handles three items without trailing newline - move middle down", () => {
+    const content = "- [ ] Task 1\n- [ ] Task 2\n- [ ] Task 3"
+    const result = moveListItemDown(content, 13, 25)
+    expect(result).toBe("- [ ] Task 1\n- [ ] Task 3\n- [ ] Task 2")
   })
 })

--- a/src/utils/reorder-list-item.ts
+++ b/src/utils/reorder-list-item.ts
@@ -308,11 +308,26 @@ export function moveListItemUp(
   const prevContent = content.slice(prevItem.start, prevItem.end)
   const separator = content.slice(prevItem.end, block.start)
 
+  // Handle case where currentContent doesn't end with a newline (last item in file without trailing newline)
+  // We need to ensure proper separation after swapping
+  let adjustedCurrentContent = currentContent
+  let adjustedPrevContent = prevContent
+
+  if (!currentContent.endsWith("\n")) {
+    // currentContent was the last item without trailing newline
+    // Add newline after it, and remove the trailing newline from prevContent if it has one
+    // (so prevContent, which becomes last, preserves the original "no trailing newline" behavior)
+    adjustedCurrentContent = currentContent + "\n"
+    if (prevContent.endsWith("\n")) {
+      adjustedPrevContent = prevContent.slice(0, -1)
+    }
+  }
+
   return (
     content.slice(0, prevItem.start) +
-    currentContent +
+    adjustedCurrentContent +
     separator +
-    prevContent +
+    adjustedPrevContent +
     content.slice(block.end)
   )
 }
@@ -336,11 +351,26 @@ export function moveListItemDown(
   const nextContent = content.slice(nextItem.start, nextItem.end)
   const separator = content.slice(block.end, nextItem.start)
 
+  // Handle case where nextContent doesn't end with a newline (last item in file without trailing newline)
+  // We need to ensure proper separation after swapping
+  let adjustedNextContent = nextContent
+  let adjustedCurrentContent = currentContent
+
+  if (!nextContent.endsWith("\n")) {
+    // nextContent was the last item without trailing newline
+    // Add newline after it, and remove the trailing newline from currentContent if it has one
+    // (so currentContent, which becomes last, preserves the original "no trailing newline" behavior)
+    adjustedNextContent = nextContent + "\n"
+    if (currentContent.endsWith("\n")) {
+      adjustedCurrentContent = currentContent.slice(0, -1)
+    }
+  }
+
   return (
     content.slice(0, block.start) +
-    nextContent +
+    adjustedNextContent +
     separator +
-    currentContent +
+    adjustedCurrentContent +
     content.slice(nextItem.end)
   )
 }


### PR DESCRIPTION
When two tasks are at the end of a note without a trailing newline and
the second-to-last task is moved down, the items would be concatenated
on the same line. This fix ensures proper newline separation when
swapping items, while preserving the original file's ending (with or
without trailing newline).

https://claude.ai/code/session_01BQdUsVxX5EhJuwaKy78d2W