### PR TITLE
Support url property in frontmatter

### DIFF
--- a/src/utils/parse-note.test.ts
+++ b/src/utils/parse-note.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, test } from "vitest"
 import { isNoteEmpty, parseNote } from "./parse-note"
 
 describe("parseNote", () => {
+  test("extracts url from frontmatter", () => {
+    const note = parseNote("1234", "---\nurl: https://example.com\n---\n# Title")
+    expect(note.url).toBe("https://example.com")
+  })
+
+  test("extracts url from link in title", () => {
+    const note = parseNote("1234", "# [Title](https://example.com)")
+    expect(note.url).toBe("https://example.com")
+  })
+
+  test("frontmatter url takes priority over link in title", () => {
+    const note = parseNote(
+      "1234",
+      "---\nurl: https://frontmatter.com\n---\n# [Title](https://title.com)",
+    )
+    expect(note.url).toBe("https://frontmatter.com")
+  })
+
   test("stores task markdown, links, and tags", () => {
     const tasks = parseNote("1234", "- [ ] Review [[project-alpha]] plan #ops").tasks
 

--- a/src/utils/parse-note.ts
+++ b/src/utils/parse-note.ts
@@ -247,6 +247,11 @@ function _parseNote(id: NoteId, content: string): Note {
     }
   }
 
+  // Check frontmatter for url (takes priority over link in title)
+  if (typeof frontmatter.url === "string") {
+    url = frontmatter.url
+  }
+
   return {
     id,
     content,


### PR DESCRIPTION
## Summary
- Adds support for `url` property in note frontmatter
- Frontmatter URL takes priority over link in title (e.g., `# [Title](url)`)
- Includes tests for both extraction methods and priority behavior

## Test plan
- [x] Unit tests added and passing
- [ ] Manual test: create note with `url:` in frontmatter and verify URL is extracted
- [ ] Manual test: verify frontmatter URL takes priority over title link

🤖 Generated with [Claude Code](https://claude.com/claude-code)