### PR TITLE
fix: bypass Vercel body size limit for Git LFS uploads

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5MB
         sourcemap: true,
         // Do not cache function routes
-        navigateFallbackDenylist: [/cors-proxy/, /file-proxy/, /git-lfs-file/, /github-auth/],
+        navigateFallbackDenylist: [/cors-proxy/, /file-proxy/, /git-lfs/, /github-auth/],
       },
       devOptions: {
         enabled: process.env.NODE_ENV === "development",


### PR DESCRIPTION
Implements direct browser-to-GitHub upload for LFS files to fix #490.
Previously, files were base64 encoded and sent through Vercel, which has
a 4.5MB body limit (~3.4MB effective with encoding overhead).

The new three-step process:
1. Get upload URL from Vercel (small request, no file content)
2. Upload binary directly to GitHub's LFS CDN (bypasses Vercel)
3. Verify upload through Vercel (small request)

This removes the practical file size limit, leaving only GitHub's ~2GB
per-file limit as a constraint.

https://claude.ai/code/session_01KWSkQBaPjVmwucotmarMJS