### PR TITLE
Add changelog infrastructure

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: changelog
+description: Update CHANGELOG.md with user-facing changes from the current branch. Use when creating a pull request or when pushing changes to a branch that already has an open pull request. Analyzes the branch diff against main, identifies user-facing changes, and adds dated entries to CHANGELOG.md.
+---
+
+# Changelog
+
+Update CHANGELOG.md with user-facing changes from the current branch.
+
+## Workflow
+
+### 1. Get the diff
+
+Get the full diff of the current branch against main:
+
+```bash
+git diff main...HEAD
+```
+
+### 2. Identify user-facing changes
+
+Analyze the diff and identify changes that affect the user. Ignore internal refactors, code style changes, and developer-only changes (test infrastructure, CI config, etc.) unless they have user-facing impact.
+
+Categorize each change:
+
+- **Added** - new features
+- **Changed** - changes in existing functionality
+- **Deprecated** - soon-to-be removed features
+- **Removed** - removed features
+- **Fixed** - bug fixes
+- **Security** - vulnerability fixes
+
+A large diff may warrant many entries — both across categories and within a single category when there are distinct changes. A small internal refactor may warrant none — if there are no user-facing changes, inform the user and stop.
+
+### 3. Write entries
+
+Each entry should:
+
+- Be written for humans — describe what the user can now do or what changed from their perspective
+- Focus on outcomes and impact, not implementation details
+- Use plain language, not technical jargon
+- Be a single concise sentence
+
+### 4. Update CHANGELOG.md
+
+Use today's date (YYYY-MM-DD) as the section heading. More recent dates go at the top (below the `# Changelog` title).
+
+Only include category subheadings (Added, Changed, etc.) that have entries.
+
+**If today's date heading already exists**: merge intelligently — add new bullets under existing category subheadings, create new subheadings as needed, skip duplicate entries.
+
+**If today's date heading does not exist**: create a new `## YYYY-MM-DD` section at the top (below the title).
+
+Format:
+
+```markdown
+# Changelog
+
+## 2026-02-06
+
+### Added
+
+- You can now export notes as PDF from the share menu.
+
+### Fixed
+
+- Fixed a bug where tags with special characters weren't searchable.
+
+## 2026-01-15
+
+### Changed
+
+- The sidebar now remembers your scroll position between sessions.
+```
+
+### 5. Commit
+
+After editing CHANGELOG.md, commit with message "Update changelog".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog


### PR DESCRIPTION
## Summary

- Adds a Claude Code skill (`.claude/skills/changelog/SKILL.md`) that automates updating the changelog when creating PRs or pushing changes
- Creates an empty `CHANGELOG.md` file as the foundation for tracking user-facing changes

## Test plan

- [ ] Verify the changelog skill is available in Claude Code sessions
- [ ] Trigger the skill on a branch with user-facing changes and confirm it writes correct entries to CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/infrastructure-only change that adds guidance and an empty changelog file without affecting runtime code paths.
> 
> **Overview**
> Adds a new Claude Code skill definition in `.claude/skills/changelog/SKILL.md` that documents a workflow for generating user-facing changelog entries from the branch diff (including categorization, dated sections, and merging rules).
> 
> Introduces a baseline `CHANGELOG.md` with only the `# Changelog` header to serve as the target file for future updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a47641b7a84ce6a476ff23a5a3b43e34b957e34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->