### PR TITLE
Use handwriting font in sign-in banner and settings footer

### DIFF
--- a/src/components/sign-in-banner.tsx
+++ b/src/components/sign-in-banner.tsx
@@ -11,7 +11,7 @@ export function SignInBanner() {
 
   return (
     <div className="flex shrink-0 flex-col justify-between bg-bg-secondary gap-4 p-4 text-text sm:flex-row items-center sm:p-2 print:hidden">
-      <span className="sm:px-2 text-text-secondary text-balance text-center sm:text-left">
+      <span className="sm:px-2 text-text-secondary text-balance text-center sm:text-left font-handwriting">
         These are demo notes. Sign in to write your own.
       </span>
       <SignInButton className="w-full sm:w-auto" />

--- a/src/routes/_appRoot.settings.tsx
+++ b/src/routes/_appRoot.settings.tsx
@@ -41,7 +41,7 @@ function RouteComponent() {
           <EditorSection />
           <AISection />
           <div className="p-5 text-text-tertiary self-center flex flex-col gap-3 items-center">
-            <span className="text-sm">
+            <span className="text-sm font-handwriting">
               Made by{" "}
               <a
                 className="link decoration-text-tertiary"


### PR DESCRIPTION
## Summary
- Add `font-handwriting` class to sign-in banner demo text
- Add `font-handwriting` class to settings page footer ("Made by" text)

## Test plan
- [ ] Verify sign-in banner text renders in handwriting font when signed out
- [ ] Verify settings footer text renders in handwriting font

🤖 Generated with [Claude Code](https://claude.com/claude-code)