### PR TITLE
Use container query for note page padding

### DIFF
--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -793,6 +793,7 @@ function NotePage() {
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
         ref={containerRef}
+        className="@container"
         onMouseDown={(event) => {
           // Double click to edit
           if (mode === "read" && event.detail > 1) {
@@ -801,7 +802,7 @@ function NotePage() {
           }
         }}
       >
-        <div className="p-5 lg:p-10">
+        <div className="p-5 @[640px]:p-10">
           <div
             className={cx(
               "flex flex-col gap-8 pb-[50vh]",


### PR DESCRIPTION
## Summary
- Switch note page padding from viewport-relative breakpoint (`lg:p-10`) to container query (`@[640px]:p-10`) so it responds to the container width instead of the viewport

## Test plan
- [ ] Open a note and resize the browser — padding should change based on the note container width, not the viewport
- [ ] Verify padding is `p-5` when container is narrow and `p-10` when container >= 640px

🤖 Generated with [Claude Code](https://claude.com/claude-code)