### PR TITLE
Move chat to standalone /ai page and misc improvements

### DIFF
--- a/src/components/nav-items.tsx
+++ b/src/components/nav-items.tsx
@@ -27,7 +27,6 @@ import {
 } from "./icons"
 import { NoteFavicon } from "./note-favicon"
 import { SyncStatusIcon, useSyncStatusText } from "./sync-status"
-import { Keys } from "./keys"
 
 const hasDailyNoteAtom = selectAtom(notesAtom, (notes) => notes.has(toDateString(new Date())))
 
@@ -249,16 +248,13 @@ export function HelpNavItem({ size }: { size: "medium" | "large" }) {
   const [isOpen, setIsOpen] = useAtom(isHelpPanelOpenAtom)
   return (
     <button
-      className="nav-item text-text-secondary group"
+      className="nav-item text-text-secondary"
       data-size={size}
       aria-pressed={isOpen}
       onClick={() => setIsOpen(!isOpen)}
     >
       {isOpen ? <CircleQuestionMarkFillIcon16 /> : <CircleQuestionMarkIcon16 />}
       Help
-      <div className="ml-auto hidden coarse:hidden! group-hover:flex group-focus-visible:flex in-aria-pressed:flex">
-        <Keys keys={["⌘", "/"]} className="text-text-tertiary epaper:in-aria-pressed:text-bg" />
-      </div>
     </button>
   )
 }

--- a/src/components/sign-in-banner.tsx
+++ b/src/components/sign-in-banner.tsx
@@ -17,7 +17,7 @@ export function SignInBanner({ className }: { className?: string }) {
         className,
       )}
     >
-      <span className="px-2 text-text-secondary text-balance text-center sm:text-left font-handwriting">
+      <span className="px-2 text-text-secondary text-balance text-center sm:text-left">
         These are demo notes. Sign in to write your own.
       </span>
       <SignInButton className="w-full sm:w-auto" />

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,150 +10,150 @@
 
 // Import Routes
 
-import { Route as rootRoute } from "./routes/__root"
-import { Route as AppRootImport } from "./routes/_appRoot"
-import { Route as AppRootIndexImport } from "./routes/_appRoot.index"
-import { Route as ShareGistIdImport } from "./routes/share.$gistId"
-import { Route as AppRootSettingsImport } from "./routes/_appRoot.settings"
-import { Route as AppRootFileImport } from "./routes/_appRoot.file"
-import { Route as AppRootChatImport } from "./routes/_appRoot.chat"
-import { Route as AppRootTagsIndexImport } from "./routes/_appRoot.tags.index"
-import { Route as AppRootNotesIndexImport } from "./routes/_appRoot.notes.index"
-import { Route as AppRootTagsSplatImport } from "./routes/_appRoot.tags_.$"
-import { Route as AppRootNotesSplatImport } from "./routes/_appRoot.notes_.$"
+import { Route as rootRoute } from './routes/__root'
+import { Route as AiImport } from './routes/ai'
+import { Route as AppRootImport } from './routes/_appRoot'
+import { Route as AppRootIndexImport } from './routes/_appRoot.index'
+import { Route as ShareGistIdImport } from './routes/share.$gistId'
+import { Route as AppRootSettingsImport } from './routes/_appRoot.settings'
+import { Route as AppRootFileImport } from './routes/_appRoot.file'
+import { Route as AppRootTagsIndexImport } from './routes/_appRoot.tags.index'
+import { Route as AppRootNotesIndexImport } from './routes/_appRoot.notes.index'
+import { Route as AppRootTagsSplatImport } from './routes/_appRoot.tags_.$'
+import { Route as AppRootNotesSplatImport } from './routes/_appRoot.notes_.$'
 
 // Create/Update Routes
 
+const AiRoute = AiImport.update({
+  id: '/ai',
+  path: '/ai',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const AppRootRoute = AppRootImport.update({
-  id: "/_appRoot",
+  id: '/_appRoot',
   getParentRoute: () => rootRoute,
 } as any)
 
 const AppRootIndexRoute = AppRootIndexImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const ShareGistIdRoute = ShareGistIdImport.update({
-  id: "/share/$gistId",
-  path: "/share/$gistId",
+  id: '/share/$gistId',
+  path: '/share/$gistId',
   getParentRoute: () => rootRoute,
 } as any)
 
 const AppRootSettingsRoute = AppRootSettingsImport.update({
-  id: "/settings",
-  path: "/settings",
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootFileRoute = AppRootFileImport.update({
-  id: "/file",
-  path: "/file",
-  getParentRoute: () => AppRootRoute,
-} as any)
-
-const AppRootChatRoute = AppRootChatImport.update({
-  id: "/chat",
-  path: "/chat",
+  id: '/file',
+  path: '/file',
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootTagsIndexRoute = AppRootTagsIndexImport.update({
-  id: "/tags/",
-  path: "/tags/",
+  id: '/tags/',
+  path: '/tags/',
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootNotesIndexRoute = AppRootNotesIndexImport.update({
-  id: "/notes/",
-  path: "/notes/",
+  id: '/notes/',
+  path: '/notes/',
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootTagsSplatRoute = AppRootTagsSplatImport.update({
-  id: "/tags_/$",
-  path: "/tags/$",
+  id: '/tags_/$',
+  path: '/tags/$',
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootNotesSplatRoute = AppRootNotesSplatImport.update({
-  id: "/notes_/$",
-  path: "/notes/$",
+  id: '/notes_/$',
+  path: '/notes/$',
   getParentRoute: () => AppRootRoute,
 } as any)
 
 // Populate the FileRoutesByPath interface
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/_appRoot": {
-      id: "/_appRoot"
-      path: ""
-      fullPath: ""
+    '/_appRoot': {
+      id: '/_appRoot'
+      path: ''
+      fullPath: ''
       preLoaderRoute: typeof AppRootImport
       parentRoute: typeof rootRoute
     }
-    "/_appRoot/chat": {
-      id: "/_appRoot/chat"
-      path: "/chat"
-      fullPath: "/chat"
-      preLoaderRoute: typeof AppRootChatImport
-      parentRoute: typeof AppRootImport
+    '/ai': {
+      id: '/ai'
+      path: '/ai'
+      fullPath: '/ai'
+      preLoaderRoute: typeof AiImport
+      parentRoute: typeof rootRoute
     }
-    "/_appRoot/file": {
-      id: "/_appRoot/file"
-      path: "/file"
-      fullPath: "/file"
+    '/_appRoot/file': {
+      id: '/_appRoot/file'
+      path: '/file'
+      fullPath: '/file'
       preLoaderRoute: typeof AppRootFileImport
       parentRoute: typeof AppRootImport
     }
-    "/_appRoot/settings": {
-      id: "/_appRoot/settings"
-      path: "/settings"
-      fullPath: "/settings"
+    '/_appRoot/settings': {
+      id: '/_appRoot/settings'
+      path: '/settings'
+      fullPath: '/settings'
       preLoaderRoute: typeof AppRootSettingsImport
       parentRoute: typeof AppRootImport
     }
-    "/share/$gistId": {
-      id: "/share/$gistId"
-      path: "/share/$gistId"
-      fullPath: "/share/$gistId"
+    '/share/$gistId': {
+      id: '/share/$gistId'
+      path: '/share/$gistId'
+      fullPath: '/share/$gistId'
       preLoaderRoute: typeof ShareGistIdImport
       parentRoute: typeof rootRoute
     }
-    "/_appRoot/": {
-      id: "/_appRoot/"
-      path: "/"
-      fullPath: "/"
+    '/_appRoot/': {
+      id: '/_appRoot/'
+      path: '/'
+      fullPath: '/'
       preLoaderRoute: typeof AppRootIndexImport
       parentRoute: typeof AppRootImport
     }
-    "/_appRoot/notes_/$": {
-      id: "/_appRoot/notes_/$"
-      path: "/notes/$"
-      fullPath: "/notes/$"
+    '/_appRoot/notes_/$': {
+      id: '/_appRoot/notes_/$'
+      path: '/notes/$'
+      fullPath: '/notes/$'
       preLoaderRoute: typeof AppRootNotesSplatImport
       parentRoute: typeof AppRootImport
     }
-    "/_appRoot/tags_/$": {
-      id: "/_appRoot/tags_/$"
-      path: "/tags/$"
-      fullPath: "/tags/$"
+    '/_appRoot/tags_/$': {
+      id: '/_appRoot/tags_/$'
+      path: '/tags/$'
+      fullPath: '/tags/$'
       preLoaderRoute: typeof AppRootTagsSplatImport
       parentRoute: typeof AppRootImport
     }
-    "/_appRoot/notes/": {
-      id: "/_appRoot/notes/"
-      path: "/notes"
-      fullPath: "/notes"
+    '/_appRoot/notes/': {
+      id: '/_appRoot/notes/'
+      path: '/notes'
+      fullPath: '/notes'
       preLoaderRoute: typeof AppRootNotesIndexImport
       parentRoute: typeof AppRootImport
     }
-    "/_appRoot/tags/": {
-      id: "/_appRoot/tags/"
-      path: "/tags"
-      fullPath: "/tags"
+    '/_appRoot/tags/': {
+      id: '/_appRoot/tags/'
+      path: '/tags'
+      fullPath: '/tags'
       preLoaderRoute: typeof AppRootTagsIndexImport
       parentRoute: typeof AppRootImport
     }
@@ -163,7 +163,6 @@ declare module "@tanstack/react-router" {
 // Create and export the route tree
 
 interface AppRootRouteChildren {
-  AppRootChatRoute: typeof AppRootChatRoute
   AppRootFileRoute: typeof AppRootFileRoute
   AppRootSettingsRoute: typeof AppRootSettingsRoute
   AppRootIndexRoute: typeof AppRootIndexRoute
@@ -174,7 +173,6 @@ interface AppRootRouteChildren {
 }
 
 const AppRootRouteChildren: AppRootRouteChildren = {
-  AppRootChatRoute: AppRootChatRoute,
   AppRootFileRoute: AppRootFileRoute,
   AppRootSettingsRoute: AppRootSettingsRoute,
   AppRootIndexRoute: AppRootIndexRoute,
@@ -184,93 +182,96 @@ const AppRootRouteChildren: AppRootRouteChildren = {
   AppRootTagsIndexRoute: AppRootTagsIndexRoute,
 }
 
-const AppRootRouteWithChildren = AppRootRoute._addFileChildren(AppRootRouteChildren)
+const AppRootRouteWithChildren =
+  AppRootRoute._addFileChildren(AppRootRouteChildren)
 
 export interface FileRoutesByFullPath {
-  "": typeof AppRootRouteWithChildren
-  "/chat": typeof AppRootChatRoute
-  "/file": typeof AppRootFileRoute
-  "/settings": typeof AppRootSettingsRoute
-  "/share/$gistId": typeof ShareGistIdRoute
-  "/": typeof AppRootIndexRoute
-  "/notes/$": typeof AppRootNotesSplatRoute
-  "/tags/$": typeof AppRootTagsSplatRoute
-  "/notes": typeof AppRootNotesIndexRoute
-  "/tags": typeof AppRootTagsIndexRoute
+  '': typeof AppRootRouteWithChildren
+  '/ai': typeof AiRoute
+  '/file': typeof AppRootFileRoute
+  '/settings': typeof AppRootSettingsRoute
+  '/share/$gistId': typeof ShareGistIdRoute
+  '/': typeof AppRootIndexRoute
+  '/notes/$': typeof AppRootNotesSplatRoute
+  '/tags/$': typeof AppRootTagsSplatRoute
+  '/notes': typeof AppRootNotesIndexRoute
+  '/tags': typeof AppRootTagsIndexRoute
 }
 
 export interface FileRoutesByTo {
-  "/chat": typeof AppRootChatRoute
-  "/file": typeof AppRootFileRoute
-  "/settings": typeof AppRootSettingsRoute
-  "/share/$gistId": typeof ShareGistIdRoute
-  "/": typeof AppRootIndexRoute
-  "/notes/$": typeof AppRootNotesSplatRoute
-  "/tags/$": typeof AppRootTagsSplatRoute
-  "/notes": typeof AppRootNotesIndexRoute
-  "/tags": typeof AppRootTagsIndexRoute
+  '/ai': typeof AiRoute
+  '/file': typeof AppRootFileRoute
+  '/settings': typeof AppRootSettingsRoute
+  '/share/$gistId': typeof ShareGistIdRoute
+  '/': typeof AppRootIndexRoute
+  '/notes/$': typeof AppRootNotesSplatRoute
+  '/tags/$': typeof AppRootTagsSplatRoute
+  '/notes': typeof AppRootNotesIndexRoute
+  '/tags': typeof AppRootTagsIndexRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
-  "/_appRoot": typeof AppRootRouteWithChildren
-  "/_appRoot/chat": typeof AppRootChatRoute
-  "/_appRoot/file": typeof AppRootFileRoute
-  "/_appRoot/settings": typeof AppRootSettingsRoute
-  "/share/$gistId": typeof ShareGistIdRoute
-  "/_appRoot/": typeof AppRootIndexRoute
-  "/_appRoot/notes_/$": typeof AppRootNotesSplatRoute
-  "/_appRoot/tags_/$": typeof AppRootTagsSplatRoute
-  "/_appRoot/notes/": typeof AppRootNotesIndexRoute
-  "/_appRoot/tags/": typeof AppRootTagsIndexRoute
+  '/_appRoot': typeof AppRootRouteWithChildren
+  '/ai': typeof AiRoute
+  '/_appRoot/file': typeof AppRootFileRoute
+  '/_appRoot/settings': typeof AppRootSettingsRoute
+  '/share/$gistId': typeof ShareGistIdRoute
+  '/_appRoot/': typeof AppRootIndexRoute
+  '/_appRoot/notes_/$': typeof AppRootNotesSplatRoute
+  '/_appRoot/tags_/$': typeof AppRootTagsSplatRoute
+  '/_appRoot/notes/': typeof AppRootNotesIndexRoute
+  '/_appRoot/tags/': typeof AppRootTagsIndexRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | ""
-    | "/chat"
-    | "/file"
-    | "/settings"
-    | "/share/$gistId"
-    | "/"
-    | "/notes/$"
-    | "/tags/$"
-    | "/notes"
-    | "/tags"
+    | ''
+    | '/ai'
+    | '/file'
+    | '/settings'
+    | '/share/$gistId'
+    | '/'
+    | '/notes/$'
+    | '/tags/$'
+    | '/notes'
+    | '/tags'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | "/chat"
-    | "/file"
-    | "/settings"
-    | "/share/$gistId"
-    | "/"
-    | "/notes/$"
-    | "/tags/$"
-    | "/notes"
-    | "/tags"
+    | '/ai'
+    | '/file'
+    | '/settings'
+    | '/share/$gistId'
+    | '/'
+    | '/notes/$'
+    | '/tags/$'
+    | '/notes'
+    | '/tags'
   id:
-    | "__root__"
-    | "/_appRoot"
-    | "/_appRoot/chat"
-    | "/_appRoot/file"
-    | "/_appRoot/settings"
-    | "/share/$gistId"
-    | "/_appRoot/"
-    | "/_appRoot/notes_/$"
-    | "/_appRoot/tags_/$"
-    | "/_appRoot/notes/"
-    | "/_appRoot/tags/"
+    | '__root__'
+    | '/_appRoot'
+    | '/ai'
+    | '/_appRoot/file'
+    | '/_appRoot/settings'
+    | '/share/$gistId'
+    | '/_appRoot/'
+    | '/_appRoot/notes_/$'
+    | '/_appRoot/tags_/$'
+    | '/_appRoot/notes/'
+    | '/_appRoot/tags/'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   AppRootRoute: typeof AppRootRouteWithChildren
+  AiRoute: typeof AiRoute
   ShareGistIdRoute: typeof ShareGistIdRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   AppRootRoute: AppRootRouteWithChildren,
+  AiRoute: AiRoute,
   ShareGistIdRoute: ShareGistIdRoute,
 }
 
@@ -285,13 +286,13 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/_appRoot",
+        "/ai",
         "/share/$gistId"
       ]
     },
     "/_appRoot": {
       "filePath": "_appRoot.tsx",
       "children": [
-        "/_appRoot/chat",
         "/_appRoot/file",
         "/_appRoot/settings",
         "/_appRoot/",
@@ -301,9 +302,8 @@ export const routeTree = rootRoute
         "/_appRoot/tags/"
       ]
     },
-    "/_appRoot/chat": {
-      "filePath": "_appRoot.chat.tsx",
-      "parent": "/_appRoot"
+    "/ai": {
+      "filePath": "ai.tsx"
     },
     "/_appRoot/file": {
       "filePath": "_appRoot.file.tsx",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,150 +10,150 @@
 
 // Import Routes
 
-import { Route as rootRoute } from './routes/__root'
-import { Route as AiImport } from './routes/ai'
-import { Route as AppRootImport } from './routes/_appRoot'
-import { Route as AppRootIndexImport } from './routes/_appRoot.index'
-import { Route as ShareGistIdImport } from './routes/share.$gistId'
-import { Route as AppRootSettingsImport } from './routes/_appRoot.settings'
-import { Route as AppRootFileImport } from './routes/_appRoot.file'
-import { Route as AppRootTagsIndexImport } from './routes/_appRoot.tags.index'
-import { Route as AppRootNotesIndexImport } from './routes/_appRoot.notes.index'
-import { Route as AppRootTagsSplatImport } from './routes/_appRoot.tags_.$'
-import { Route as AppRootNotesSplatImport } from './routes/_appRoot.notes_.$'
+import { Route as rootRoute } from "./routes/__root"
+import { Route as AiImport } from "./routes/ai"
+import { Route as AppRootImport } from "./routes/_appRoot"
+import { Route as AppRootIndexImport } from "./routes/_appRoot.index"
+import { Route as ShareGistIdImport } from "./routes/share.$gistId"
+import { Route as AppRootSettingsImport } from "./routes/_appRoot.settings"
+import { Route as AppRootFileImport } from "./routes/_appRoot.file"
+import { Route as AppRootTagsIndexImport } from "./routes/_appRoot.tags.index"
+import { Route as AppRootNotesIndexImport } from "./routes/_appRoot.notes.index"
+import { Route as AppRootTagsSplatImport } from "./routes/_appRoot.tags_.$"
+import { Route as AppRootNotesSplatImport } from "./routes/_appRoot.notes_.$"
 
 // Create/Update Routes
 
 const AiRoute = AiImport.update({
-  id: '/ai',
-  path: '/ai',
+  id: "/ai",
+  path: "/ai",
   getParentRoute: () => rootRoute,
 } as any)
 
 const AppRootRoute = AppRootImport.update({
-  id: '/_appRoot',
+  id: "/_appRoot",
   getParentRoute: () => rootRoute,
 } as any)
 
 const AppRootIndexRoute = AppRootIndexImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const ShareGistIdRoute = ShareGistIdImport.update({
-  id: '/share/$gistId',
-  path: '/share/$gistId',
+  id: "/share/$gistId",
+  path: "/share/$gistId",
   getParentRoute: () => rootRoute,
 } as any)
 
 const AppRootSettingsRoute = AppRootSettingsImport.update({
-  id: '/settings',
-  path: '/settings',
+  id: "/settings",
+  path: "/settings",
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootFileRoute = AppRootFileImport.update({
-  id: '/file',
-  path: '/file',
+  id: "/file",
+  path: "/file",
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootTagsIndexRoute = AppRootTagsIndexImport.update({
-  id: '/tags/',
-  path: '/tags/',
+  id: "/tags/",
+  path: "/tags/",
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootNotesIndexRoute = AppRootNotesIndexImport.update({
-  id: '/notes/',
-  path: '/notes/',
+  id: "/notes/",
+  path: "/notes/",
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootTagsSplatRoute = AppRootTagsSplatImport.update({
-  id: '/tags_/$',
-  path: '/tags/$',
+  id: "/tags_/$",
+  path: "/tags/$",
   getParentRoute: () => AppRootRoute,
 } as any)
 
 const AppRootNotesSplatRoute = AppRootNotesSplatImport.update({
-  id: '/notes_/$',
-  path: '/notes/$',
+  id: "/notes_/$",
+  path: "/notes/$",
   getParentRoute: () => AppRootRoute,
 } as any)
 
 // Populate the FileRoutesByPath interface
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/_appRoot': {
-      id: '/_appRoot'
-      path: ''
-      fullPath: ''
+    "/_appRoot": {
+      id: "/_appRoot"
+      path: ""
+      fullPath: ""
       preLoaderRoute: typeof AppRootImport
       parentRoute: typeof rootRoute
     }
-    '/ai': {
-      id: '/ai'
-      path: '/ai'
-      fullPath: '/ai'
+    "/ai": {
+      id: "/ai"
+      path: "/ai"
+      fullPath: "/ai"
       preLoaderRoute: typeof AiImport
       parentRoute: typeof rootRoute
     }
-    '/_appRoot/file': {
-      id: '/_appRoot/file'
-      path: '/file'
-      fullPath: '/file'
+    "/_appRoot/file": {
+      id: "/_appRoot/file"
+      path: "/file"
+      fullPath: "/file"
       preLoaderRoute: typeof AppRootFileImport
       parentRoute: typeof AppRootImport
     }
-    '/_appRoot/settings': {
-      id: '/_appRoot/settings'
-      path: '/settings'
-      fullPath: '/settings'
+    "/_appRoot/settings": {
+      id: "/_appRoot/settings"
+      path: "/settings"
+      fullPath: "/settings"
       preLoaderRoute: typeof AppRootSettingsImport
       parentRoute: typeof AppRootImport
     }
-    '/share/$gistId': {
-      id: '/share/$gistId'
-      path: '/share/$gistId'
-      fullPath: '/share/$gistId'
+    "/share/$gistId": {
+      id: "/share/$gistId"
+      path: "/share/$gistId"
+      fullPath: "/share/$gistId"
       preLoaderRoute: typeof ShareGistIdImport
       parentRoute: typeof rootRoute
     }
-    '/_appRoot/': {
-      id: '/_appRoot/'
-      path: '/'
-      fullPath: '/'
+    "/_appRoot/": {
+      id: "/_appRoot/"
+      path: "/"
+      fullPath: "/"
       preLoaderRoute: typeof AppRootIndexImport
       parentRoute: typeof AppRootImport
     }
-    '/_appRoot/notes_/$': {
-      id: '/_appRoot/notes_/$'
-      path: '/notes/$'
-      fullPath: '/notes/$'
+    "/_appRoot/notes_/$": {
+      id: "/_appRoot/notes_/$"
+      path: "/notes/$"
+      fullPath: "/notes/$"
       preLoaderRoute: typeof AppRootNotesSplatImport
       parentRoute: typeof AppRootImport
     }
-    '/_appRoot/tags_/$': {
-      id: '/_appRoot/tags_/$'
-      path: '/tags/$'
-      fullPath: '/tags/$'
+    "/_appRoot/tags_/$": {
+      id: "/_appRoot/tags_/$"
+      path: "/tags/$"
+      fullPath: "/tags/$"
       preLoaderRoute: typeof AppRootTagsSplatImport
       parentRoute: typeof AppRootImport
     }
-    '/_appRoot/notes/': {
-      id: '/_appRoot/notes/'
-      path: '/notes'
-      fullPath: '/notes'
+    "/_appRoot/notes/": {
+      id: "/_appRoot/notes/"
+      path: "/notes"
+      fullPath: "/notes"
       preLoaderRoute: typeof AppRootNotesIndexImport
       parentRoute: typeof AppRootImport
     }
-    '/_appRoot/tags/': {
-      id: '/_appRoot/tags/'
-      path: '/tags'
-      fullPath: '/tags'
+    "/_appRoot/tags/": {
+      id: "/_appRoot/tags/"
+      path: "/tags"
+      fullPath: "/tags"
       preLoaderRoute: typeof AppRootTagsIndexImport
       parentRoute: typeof AppRootImport
     }
@@ -182,84 +182,83 @@ const AppRootRouteChildren: AppRootRouteChildren = {
   AppRootTagsIndexRoute: AppRootTagsIndexRoute,
 }
 
-const AppRootRouteWithChildren =
-  AppRootRoute._addFileChildren(AppRootRouteChildren)
+const AppRootRouteWithChildren = AppRootRoute._addFileChildren(AppRootRouteChildren)
 
 export interface FileRoutesByFullPath {
-  '': typeof AppRootRouteWithChildren
-  '/ai': typeof AiRoute
-  '/file': typeof AppRootFileRoute
-  '/settings': typeof AppRootSettingsRoute
-  '/share/$gistId': typeof ShareGistIdRoute
-  '/': typeof AppRootIndexRoute
-  '/notes/$': typeof AppRootNotesSplatRoute
-  '/tags/$': typeof AppRootTagsSplatRoute
-  '/notes': typeof AppRootNotesIndexRoute
-  '/tags': typeof AppRootTagsIndexRoute
+  "": typeof AppRootRouteWithChildren
+  "/ai": typeof AiRoute
+  "/file": typeof AppRootFileRoute
+  "/settings": typeof AppRootSettingsRoute
+  "/share/$gistId": typeof ShareGistIdRoute
+  "/": typeof AppRootIndexRoute
+  "/notes/$": typeof AppRootNotesSplatRoute
+  "/tags/$": typeof AppRootTagsSplatRoute
+  "/notes": typeof AppRootNotesIndexRoute
+  "/tags": typeof AppRootTagsIndexRoute
 }
 
 export interface FileRoutesByTo {
-  '/ai': typeof AiRoute
-  '/file': typeof AppRootFileRoute
-  '/settings': typeof AppRootSettingsRoute
-  '/share/$gistId': typeof ShareGistIdRoute
-  '/': typeof AppRootIndexRoute
-  '/notes/$': typeof AppRootNotesSplatRoute
-  '/tags/$': typeof AppRootTagsSplatRoute
-  '/notes': typeof AppRootNotesIndexRoute
-  '/tags': typeof AppRootTagsIndexRoute
+  "/ai": typeof AiRoute
+  "/file": typeof AppRootFileRoute
+  "/settings": typeof AppRootSettingsRoute
+  "/share/$gistId": typeof ShareGistIdRoute
+  "/": typeof AppRootIndexRoute
+  "/notes/$": typeof AppRootNotesSplatRoute
+  "/tags/$": typeof AppRootTagsSplatRoute
+  "/notes": typeof AppRootNotesIndexRoute
+  "/tags": typeof AppRootTagsIndexRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
-  '/_appRoot': typeof AppRootRouteWithChildren
-  '/ai': typeof AiRoute
-  '/_appRoot/file': typeof AppRootFileRoute
-  '/_appRoot/settings': typeof AppRootSettingsRoute
-  '/share/$gistId': typeof ShareGistIdRoute
-  '/_appRoot/': typeof AppRootIndexRoute
-  '/_appRoot/notes_/$': typeof AppRootNotesSplatRoute
-  '/_appRoot/tags_/$': typeof AppRootTagsSplatRoute
-  '/_appRoot/notes/': typeof AppRootNotesIndexRoute
-  '/_appRoot/tags/': typeof AppRootTagsIndexRoute
+  "/_appRoot": typeof AppRootRouteWithChildren
+  "/ai": typeof AiRoute
+  "/_appRoot/file": typeof AppRootFileRoute
+  "/_appRoot/settings": typeof AppRootSettingsRoute
+  "/share/$gistId": typeof ShareGistIdRoute
+  "/_appRoot/": typeof AppRootIndexRoute
+  "/_appRoot/notes_/$": typeof AppRootNotesSplatRoute
+  "/_appRoot/tags_/$": typeof AppRootTagsSplatRoute
+  "/_appRoot/notes/": typeof AppRootNotesIndexRoute
+  "/_appRoot/tags/": typeof AppRootTagsIndexRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | ''
-    | '/ai'
-    | '/file'
-    | '/settings'
-    | '/share/$gistId'
-    | '/'
-    | '/notes/$'
-    | '/tags/$'
-    | '/notes'
-    | '/tags'
+    | ""
+    | "/ai"
+    | "/file"
+    | "/settings"
+    | "/share/$gistId"
+    | "/"
+    | "/notes/$"
+    | "/tags/$"
+    | "/notes"
+    | "/tags"
   fileRoutesByTo: FileRoutesByTo
   to:
-    | '/ai'
-    | '/file'
-    | '/settings'
-    | '/share/$gistId'
-    | '/'
-    | '/notes/$'
-    | '/tags/$'
-    | '/notes'
-    | '/tags'
+    | "/ai"
+    | "/file"
+    | "/settings"
+    | "/share/$gistId"
+    | "/"
+    | "/notes/$"
+    | "/tags/$"
+    | "/notes"
+    | "/tags"
   id:
-    | '__root__'
-    | '/_appRoot'
-    | '/ai'
-    | '/_appRoot/file'
-    | '/_appRoot/settings'
-    | '/share/$gistId'
-    | '/_appRoot/'
-    | '/_appRoot/notes_/$'
-    | '/_appRoot/tags_/$'
-    | '/_appRoot/notes/'
-    | '/_appRoot/tags/'
+    | "__root__"
+    | "/_appRoot"
+    | "/ai"
+    | "/_appRoot/file"
+    | "/_appRoot/settings"
+    | "/share/$gistId"
+    | "/_appRoot/"
+    | "/_appRoot/notes_/$"
+    | "/_appRoot/tags_/$"
+    | "/_appRoot/notes/"
+    | "/_appRoot/tags/"
   fileRoutesById: FileRoutesById
 }
 

--- a/src/routes/_appRoot.settings.tsx
+++ b/src/routes/_appRoot.settings.tsx
@@ -41,7 +41,7 @@ function RouteComponent() {
           <EditorSection />
           <AISection />
           <div className="p-5 text-text-tertiary self-center flex flex-col gap-3 items-center">
-            <span className="text-sm font-handwriting">
+            <span className="text-sm">
               Made by{" "}
               <a
                 className="link decoration-text-tertiary"
@@ -62,7 +62,7 @@ function RouteComponent() {
               </a>
             </span>
             <a href="https://colebemis.com" target="_blank" rel="noopener noreferrer">
-              <Signature width={120} />
+              <Signature width={100} />
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Move chat route from `/_appRoot/chat` to a standalone `/ai` page with its own auth/repo/cloning state handling
- Remove keyboard shortcut display from Help nav item
- (Prior commits) Add TMDB poster support for IMDb-linked notes, rename favicon files, use container queries for note page padding, remove handwriting font

## Test plan
- [ ] Visit `/ai` and verify sign-in, repo selection, cloning, and chat states work correctly
- [ ] Verify Help nav item still toggles the help panel
- [ ] Verify TMDB posters appear for IMDb-linked notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)