### PR TITLE
Add searchable note picker for moving tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improved
 
-- You can now quickly move a task to any note, not just the predefined date shortcuts (Today, Tomorrow, Next week). Click the "Move to" button on a task and search for a note by name, use natural language dates like "friday" or "next month", or create a new note right from the picker.
+- Move tasks to any note, not just Today/Tomorrow/Next week. The "Move to" button now lets you search across your notes, use natural dates ("friday", "next month", "in 2 weeks"), or create a new note on the fly.
 
 ## 2026-W06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-W08
+
+### Improved
+
+- You can now quickly move a task to any note, not just the predefined date shortcuts (Today, Tomorrow, Next week). Click the "Move to" button on a task and search for a note by name, use natural language dates like "friday" or "next month", or create a new note right from the picker.
+
 ## 2026-W06
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improved
 
-- Move tasks to any note, not just Today/Tomorrow/Next week. The "Move to" button now lets you search across your notes, use natural dates ("friday", "next month", "in 2 weeks"), or create a new note on the fly.
+- Move tasks to any note, not just Today/Tomorrow/Next week. The "Move to" menu now lets you search across your notes, use natural dates ("friday", "next month", "in 2 weeks"), or create a new note on the fly.
 
 ## 2026-W06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/react": "^3.0.6",
-        "@base-ui/react": "^1.1.0",
+        "@base-ui/react": "^1.2.0",
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.7.0",
         "@codemirror/lang-markdown": "^6.2.5",
@@ -1984,9 +1984,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2054,16 +2054,15 @@
       }
     },
     "node_modules/@base-ui/react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.1.0.tgz",
-      "integrity": "sha512-ikcJRNj1mOiF2HZ5jQHrXoVoHcNHdBU5ejJljcBl+VTLoYXR6FidjTN86GjO6hyshi6TZFuNvv0dEOgaOFv6Lw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.2.0.tgz",
+      "integrity": "sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@base-ui/utils": "0.2.4",
+        "@babel/runtime": "^7.28.6",
+        "@base-ui/utils": "0.2.5",
         "@floating-ui/react-dom": "^2.1.6",
         "@floating-ui/utils": "^0.2.10",
-        "reselect": "^5.1.1",
         "tabbable": "^6.4.0",
         "use-sync-external-store": "^1.6.0"
       },
@@ -2118,12 +2117,12 @@
       }
     },
     "node_modules/@base-ui/utils": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.4.tgz",
-      "integrity": "sha512-smZwpMhjO29v+jrZusBSc5T+IJ3vBb9cjIiBjtKcvWmRj9Z4DWGVR3efr1eHR56/bqY5a4qyY9ElkOY5ljo3ng==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.5.tgz",
+      "integrity": "sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
+        "@babel/runtime": "^7.28.6",
         "@floating-ui/utils": "^0.2.10",
         "reselect": "^5.1.1",
         "use-sync-external-store": "^1.6.0"
@@ -32008,9 +32007,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
     },
     "@babel/runtime-corejs3": {
       "version": "7.28.4",
@@ -32058,15 +32057,14 @@
       }
     },
     "@base-ui/react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.1.0.tgz",
-      "integrity": "sha512-ikcJRNj1mOiF2HZ5jQHrXoVoHcNHdBU5ejJljcBl+VTLoYXR6FidjTN86GjO6hyshi6TZFuNvv0dEOgaOFv6Lw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.2.0.tgz",
+      "integrity": "sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw==",
       "requires": {
-        "@babel/runtime": "^7.28.4",
-        "@base-ui/utils": "0.2.4",
+        "@babel/runtime": "^7.28.6",
+        "@base-ui/utils": "0.2.5",
         "@floating-ui/react-dom": "^2.1.6",
         "@floating-ui/utils": "^0.2.10",
-        "reselect": "^5.1.1",
         "tabbable": "^6.4.0",
         "use-sync-external-store": "^1.6.0"
       },
@@ -32099,11 +32097,11 @@
       }
     },
     "@base-ui/utils": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.4.tgz",
-      "integrity": "sha512-smZwpMhjO29v+jrZusBSc5T+IJ3vBb9cjIiBjtKcvWmRj9Z4DWGVR3efr1eHR56/bqY5a4qyY9ElkOY5ljo3ng==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.5.tgz",
+      "integrity": "sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw==",
       "requires": {
-        "@babel/runtime": "^7.28.4",
+        "@babel/runtime": "^7.28.6",
         "@floating-ui/utils": "^0.2.10",
         "reselect": "^5.1.1",
         "use-sync-external-store": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.6",
-    "@base-ui/react": "^1.1.0",
+    "@base-ui/react": "^1.2.0",
     "@codemirror/autocomplete": "^6.1.0",
     "@codemirror/commands": "^6.7.0",
     "@codemirror/lang-markdown": "^6.2.5",

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -466,7 +466,7 @@ function CommandItem({ children, value, icon, description, onSelect }: CommandIt
         <div className="grid h-4 w-4 place-items-center text-text-secondary">{icon}</div>
         <div className="grow truncate">{children}</div>
         {description ? <span className="shrink-0 text-text-secondary">{description}</span> : null}
-        <span className="hidden leading-none text-text-secondary [[aria-selected]_&]:inline epaper:[[aria-selected]_&]:text-bg">
+        <span className="hidden leading-none text-text-secondary in-aria-selected:inline epaper:in-aria-selected:text-bg">
           ⏎
         </span>
       </div>

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -29,12 +29,12 @@ function Content({
         <Menu.Popup
           className={cx(
             "card-2 z-20 grid place-items-stretch overflow-hidden rounded-lg print:hidden outline-hidden",
-            "origin-[var(--transform-origin)] transition-[transform,scale,opacity] epaper:transition-none data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0",
+            "origin-(--transform-origin) transition-[transform,scale,opacity] epaper:transition-none data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0",
             className,
           )}
           style={{ width }}
         >
-          <div className="grid max-h-[60svh] scroll-py-1 overflow-auto p-1">{children}</div>
+          <div className="grid max-h-[45svh] scroll-py-1 overflow-auto p-1">{children}</div>
         </Menu.Popup>
       </Menu.Positioner>
     </Menu.Portal>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -424,6 +424,21 @@ export function ArrowDownToLineIcon16(props: IconProps) {
   return <ArrowLeftToLineIcon16 {...props} className={cx("-rotate-90", props.className)} />
 }
 
+export function ArrowDownRightIcon16(props: IconProps) {
+  return (
+    <Icon size={16} {...props}>
+      <path
+        data-epaper="hide"
+        d="M11.7799 13.78C11.487 14.0728 11.0122 14.0729 10.7193 13.78C10.4269 13.4871 10.4266 13.0122 10.7193 12.7194L13.4391 9.99971H3.9996C2.61911 9.99946 1.49963 8.88024 1.4996 7.49971V3.24971C1.49981 2.83582 1.83572 2.49995 2.2496 2.49971C2.66368 2.49971 2.99939 2.83567 2.9996 3.24971V7.49971C2.99963 8.05182 3.44754 8.49946 3.9996 8.49971H13.4391L10.7193 5.77998C10.4269 5.48706 10.4266 5.01219 10.7193 4.71943C11.0121 4.42668 11.4869 4.42696 11.7799 4.71943L15.7799 8.71943C16.0728 9.01233 16.0728 9.48709 15.7799 9.77998L11.7799 13.78Z"
+      />
+      <path
+        data-epaper="show"
+        d="M10.1895 13.2503L13.4395 10.0003H1.5V2.50027H3V8.50027H13.4395L10.1895 5.25027L11.25 4.18973L16.3105 9.25027L11.25 14.3108L10.1895 13.2503Z"
+      />
+    </Icon>
+  )
+}
+
 export function ChevronLeftIcon16(props: IconProps) {
   return (
     <Icon size={16} {...props}>

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -765,7 +765,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
     >
       <div
         className={cx("flex p-1.5 gap-1.5 rounded-lg", {
-          "relative fine:pr-[74px] coarse:pr-12 group/task": isTask && onChange,
+          "relative pr-10 sm:fine:pr-[74px] coarse:pr-12 group/task": isTask && onChange,
           "hover:bg-bg-hover": isTask && !isMenuOpen,
         })}
       >
@@ -830,7 +830,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
                   className={cx(
                     "opacity-0 group-hover/task:opacity-100 focus-visible:opacity-100",
                     isMenuOpen && "opacity-100",
-                    "hidden fine:inline-flex coarse:hidden!",
+                    "hidden sm:fine:inline-flex coarse:hidden!",
                   )}
                 >
                   <ArrowDownRightIcon16 />
@@ -853,7 +853,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
                 }
               />
               <DropdownMenu.Content align="end" width={280} sideOffset={8}>
-                <div className="block fine:hidden coarse:block">
+                <div className="sm:fine:hidden">
                   <DropdownMenu.Item
                     icon={<ArrowDownRightIcon16 />}
                     onClick={() => setIsMoveDialogOpen(true)}

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -765,7 +765,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
     >
       <div
         className={cx("flex p-1.5 gap-1.5 rounded-lg", {
-          "relative pr-10 @[640px]:fine:pr-[74px] coarse:pr-12 group/task": isTask && onChange,
+          "relative fine:pr-[74px] coarse:pr-12 group/task": isTask && onChange,
           "hover:bg-bg-hover": isTask && !isMenuOpen,
         })}
       >
@@ -830,7 +830,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
                   className={cx(
                     "opacity-0 group-hover/task:opacity-100 focus-visible:opacity-100",
                     isMenuOpen && "opacity-100",
-                    "hidden @[640px]:inline-flex coarse:hidden! coarse:pointer-events-none",
+                    "hidden fine:inline-flex coarse:hidden!",
                   )}
                 >
                   <ArrowDownRightIcon16 />
@@ -853,7 +853,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
                 }
               />
               <DropdownMenu.Content align="end" width={280} sideOffset={8}>
-                <div className="block fine:@[640px]:hidden">
+                <div className="block fine:hidden coarse:block">
                   <DropdownMenu.Item
                     icon={<ArrowDownRightIcon16 />}
                     onClick={() => setIsMoveDialogOpen(true)}

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -825,7 +825,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
               }}
               trigger={
                 <IconButton
-                  aria-label="Move to"
+                  aria-label="Move to…"
                   tooltipSide="top"
                   className={cx(
                     "opacity-0 group-hover/task:opacity-100 focus-visible:opacity-100",
@@ -858,7 +858,7 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
                     icon={<ArrowDownRightIcon16 />}
                     onClick={() => setIsMoveDialogOpen(true)}
                   >
-                    Move to
+                    Move to…
                   </DropdownMenu.Item>
                   <DropdownMenu.Separator />
                 </div>

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@tanstack/react-router"
-import { addDays, isWeekend, nextMonday, nextSaturday } from "date-fns"
 import React from "react"
 import ReactMarkdown from "react-markdown"
 import { CodeProps, LiProps } from "react-markdown/lib/ast-to-react"
@@ -12,7 +11,6 @@ import { z } from "zod"
 import { UPLOADS_DIR } from "../hooks/attach-file"
 import { useNoteById, useSaveNote } from "../hooks/note"
 import { useMoveTask } from "../hooks/task"
-import { formatDate, toDateString } from "../utils/date"
 import { generateNoteId } from "../utils/note-id"
 import {
   canMoveListItemUp,
@@ -52,7 +50,6 @@ import {
   ArrowDownToLineIcon16,
   ArrowUpIcon16,
   ArrowUpToLineIcon16,
-  CalendarDateIcon16,
   CopyIcon16,
   CutIcon16,
   ErrorIcon16,
@@ -664,61 +661,6 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
     [markdownBodyStartOffset, markdown, moveTask, node.position, noteId],
   )
 
-  // Memoize date options to avoid recalculating on every render
-  const dateOptions = React.useMemo(() => {
-    const now = new Date()
-    const today = now
-    const tomorrow = addDays(now, 1)
-    const saturday = nextSaturday(now)
-    const monday = nextMonday(now)
-
-    type DateOption = {
-      label: string
-      icon: React.ReactNode
-      targetId: string
-      trailingText: string
-    }
-
-    const options: DateOption[] = [
-      {
-        label: "Today",
-        icon: <CalendarDateIcon16 date={today.getDate()} />,
-        targetId: toDateString(today),
-        trailingText: formatDate(toDateString(today)),
-      },
-      {
-        label: "Tomorrow",
-        icon: <CalendarDateIcon16 date={tomorrow.getDate()} />,
-        targetId: toDateString(tomorrow),
-        trailingText: formatDate(toDateString(tomorrow)),
-      },
-      {
-        label: isWeekend(now) ? "Next weekend" : "This weekend",
-        icon: <CalendarDateIcon16 date={saturday.getDate()} />,
-        targetId: toDateString(saturday),
-        trailingText: formatDate(toDateString(saturday)),
-      },
-      {
-        label: "Next week",
-        icon: <CalendarDateIcon16 date={monday.getDate()} />,
-        targetId: toDateString(monday),
-        trailingText: formatDate(toDateString(monday)),
-      },
-    ]
-
-    // Filter out current note and duplicates, then sort by date
-    const seen = new Set<string>()
-    const sortedOptions = options
-      .filter((option) => {
-        if (option.targetId === noteId || seen.has(option.targetId)) return false
-        seen.add(option.targetId)
-        return true
-      })
-      .sort((a, b) => a.targetId.localeCompare(b.targetId))
-
-    return sortedOptions
-  }, [noteId])
-
   // Get the task line text for copy/cut operations
   const getTaskLine = React.useCallback(() => {
     if (!node.position) return ""
@@ -816,7 +758,8 @@ function ListItem({ node, children, ordered, className, ...props }: LiProps) {
       {...props}
       className={cx(
         "rounded-lg",
-        isMenuOpen && "bg-bg-selection epaper:bg-transparent epaper:ring-1 epaper:ring-border epaper:ring-inset",
+        isMenuOpen &&
+          "bg-bg-selection epaper:bg-transparent epaper:ring-1 epaper:ring-border epaper:ring-inset",
         className,
       )}
     >

--- a/src/components/note-picker.tsx
+++ b/src/components/note-picker.tsx
@@ -1,0 +1,270 @@
+import React from "react"
+import { parseDate } from "chrono-node"
+import { Command } from "cmdk"
+import { useDebounce } from "use-debounce"
+import { Popover } from "@base-ui/react"
+import * as Dialog from "@radix-ui/react-dialog"
+import { useSearchNotes } from "../hooks/search-notes"
+import { addDays } from "date-fns"
+import { toDateString, formatDate, formatDateDistance, formatWeekDistance } from "../utils/date"
+import { CalendarDateIcon16, ComposeIcon16, PinFillIcon12 } from "./icons"
+import { NoteFavicon } from "./note-favicon"
+import { cx } from "../utils/cx"
+
+type NotePickerProps = {
+  placeholder?: string
+  size?: "small" | "large"
+  exclude?: string[]
+  onSelect: (noteId: string) => void
+  onCreateNote?: (title: string) => void
+  onClose: () => void
+}
+
+type Item = {
+  value: string
+  label: React.ReactNode
+  icon: React.ReactNode
+  description?: React.ReactNode
+  onSelect: () => void
+}
+
+export function NotePicker({
+  placeholder = "Search…",
+  size = "small",
+  exclude = [],
+  onSelect,
+  onCreateNote,
+  onClose,
+}: NotePickerProps) {
+  const searchNotes = useSearchNotes()
+  const [query, setQuery] = React.useState("")
+  const [deferredQuery] = useDebounce(query, 150)
+
+  const items = React.useMemo(() => {
+    const result: Item[] = []
+
+    if (!deferredQuery) {
+      const today = toDateString(new Date())
+      const tomorrow = toDateString(addDays(new Date(), 1))
+      for (const id of [today, tomorrow]) {
+        if (exclude.includes(id)) continue
+        result.push({
+          value: id,
+          label: formatDate(id),
+          icon: <CalendarDateIcon16 date={new Date(id).getUTCDate()} />,
+          description: formatDateDistance(id),
+          onSelect: () => { onSelect(id); onClose() },
+        })
+      }
+    }
+
+    const parsedDate = parseDate(deferredQuery)
+    const dateString = parsedDate ? toDateString(parsedDate) : ""
+    if (dateString && !exclude.includes(dateString)) {
+      result.push({
+        value: dateString,
+        label: formatDate(dateString),
+        icon: <CalendarDateIcon16 date={parsedDate?.getDate()} />,
+        description: formatDateDistance(dateString),
+        onSelect: () => { onSelect(dateString); onClose() },
+      })
+    }
+
+    const resultIds = new Set(result.map((i) => i.value))
+    const searchResults = searchNotes(deferredQuery)
+      .filter((note) => !exclude.includes(note.id) && !resultIds.has(note.id))
+      .slice(0, 8)
+
+    for (const note of searchResults) {
+      result.push({
+        value: note.id,
+        label: note.pinned ? <span className="inline-flex gap-2 items-center">{note.displayName}</span> : note.displayName,
+        icon: <NoteFavicon note={note} />,
+        description:
+          note.type === "daily"
+            ? formatDateDistance(note.id)
+            : note.type === "weekly"
+              ? formatWeekDistance(note.id)
+              : note.pinned ? <PinFillIcon12 className="text-text-pinned" /> : null,
+        onSelect: () => { onSelect(note.id); onClose() },
+      })
+    }
+
+    if (deferredQuery && onCreateNote) {
+      result.push({
+        value: "__create__",
+        label: `Create new note "${deferredQuery}"`,
+        icon: <ComposeIcon16 />,
+        onSelect: () => { onCreateNote(deferredQuery); onClose() },
+      })
+    }
+
+    return result.slice(0, 5)
+  }, [deferredQuery, exclude, searchNotes, onCreateNote, onSelect, onClose])
+
+  return (
+    <Command
+      shouldFilter={false}
+      className="overflow-hidden"
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && !query) {
+          onClose()
+          event.preventDefault()
+        }
+      }}
+    >
+      <Command.Input
+        placeholder={placeholder}
+        value={query}
+        onValueChange={setQuery}
+        autoFocus
+        className={cx(
+          "placeholder:text-text-tertiary w-full outline-none border-b border-border-secondary",
+          size === "small" && "px-4 h-10",
+          size === "large" && "bg-transparent px-5 py-4 text-lg leading-none",
+        )}
+      />
+      <Command.List
+        className={cx(
+          "max-h-[min(400px,42vh)] overflow-y-auto overflow-x-hidden",
+          size === "small" && "p-1 scroll-py-1",
+          size === "large" && "p-2 scroll-py-2",
+        )}
+      >
+        {items.map((item) => (
+          <CommandItem
+            key={item.value}
+            value={item.value}
+            icon={item.icon}
+            description={item.description}
+            onSelect={item.onSelect}
+            size={size}
+          >
+            {item.label}
+          </CommandItem>
+        ))}
+      </Command.List>
+    </Command>
+  )
+}
+
+type CommandItemProps = {
+  children: React.ReactNode
+  value?: string
+  icon?: React.ReactNode
+  description?: React.ReactNode
+  onSelect?: () => void
+  size?: "small" | "large"
+}
+
+function CommandItem({
+  children,
+  value,
+  icon,
+  description,
+  onSelect,
+  size = "small",
+}: CommandItemProps) {
+  return (
+    <Command.Item
+      value={value}
+      onSelect={onSelect}
+      className={cx(
+        "flex items-center gap-3 cursor-pointer select-none rounded aria-selected:bg-bg-hover",
+        "epaper:aria-selected:bg-text epaper:aria-selected:text-bg epaper:aria-selected:[&_svg]:text-bg",
+        size === "small" && "h-8 px-3",
+        size === "large" && "h-10 px-3",
+      )}
+    >
+      <div className="grid h-4 w-4 place-items-center text-text-secondary">{icon}</div>
+      <div className="grow truncate">{children}</div>
+      {description ? <span className="shrink-0 text-text-secondary">{description}</span> : null}
+    </Command.Item>
+  )
+}
+
+type NotePickerPopoverProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  trigger: React.ReactElement
+  placeholder?: string
+  exclude?: string[]
+  onSelect: (noteId: string) => void
+  onCreateNote?: (title: string) => void
+}
+
+export function NotePickerPopover({
+  open,
+  onOpenChange,
+  trigger,
+  placeholder,
+  exclude,
+  onSelect,
+  onCreateNote,
+}: NotePickerPopoverProps) {
+  return (
+    <Popover.Root open={open} onOpenChange={onOpenChange}>
+      <Popover.Trigger render={trigger} />
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={8} align="end">
+          <Popover.Popup
+            className={cx(
+              "card-2 z-20 w-sm grid place-items-stretch rounded-lg print:hidden outline-hidden",
+              "origin-(--transform-origin) transition-[transform,scale,opacity] epaper:transition-none",
+              "data-ending-style:scale-95 data-ending-style:opacity-0",
+              "data-starting-style:scale-95 data-starting-style:opacity-0",
+            )}
+          >
+            <NotePicker
+              size="small"
+              placeholder={placeholder}
+              exclude={exclude ?? []}
+              onSelect={onSelect}
+              onCreateNote={onCreateNote}
+              onClose={() => onOpenChange(false)}
+            />
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  )
+}
+
+type NotePickerDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  placeholder?: string
+  exclude?: string[]
+  onSelect: (noteId: string) => void
+  onCreateNote?: (title: string) => void
+}
+
+export function NotePickerDialog({
+  open,
+  onOpenChange,
+  placeholder,
+  exclude,
+  onSelect,
+  onCreateNote,
+}: NotePickerDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-20" />
+        <Dialog.Content
+          className="card-3 rounded-xl! fixed left-1/2 top-3 z-20 w-[calc(100vw-24px)] max-w-2xl -translate-x-1/2 overflow-hidden focus:outline-hidden sm:top-[10vh]"
+          aria-label="Move task to note"
+        >
+          <NotePicker
+            size="large"
+            placeholder={placeholder}
+            exclude={exclude ?? []}
+            onSelect={onSelect}
+            onCreateNote={onCreateNote}
+            onClose={() => onOpenChange(false)}
+          />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/components/note-picker.tsx
+++ b/src/components/note-picker.tsx
@@ -53,7 +53,10 @@ export function NotePicker({
           label: formatDate(id),
           icon: <CalendarDateIcon16 date={new Date(id).getUTCDate()} />,
           description: formatDateDistance(id),
-          onSelect: () => { onSelect(id); onClose() },
+          onSelect: () => {
+            onSelect(id)
+            onClose()
+          },
         })
       }
     }
@@ -66,7 +69,10 @@ export function NotePicker({
         label: formatDate(dateString),
         icon: <CalendarDateIcon16 date={parsedDate?.getDate()} />,
         description: formatDateDistance(dateString),
-        onSelect: () => { onSelect(dateString); onClose() },
+        onSelect: () => {
+          onSelect(dateString)
+          onClose()
+        },
       })
     }
 
@@ -78,15 +84,24 @@ export function NotePicker({
     for (const note of searchResults) {
       result.push({
         value: note.id,
-        label: note.pinned ? <span className="inline-flex gap-2 items-center">{note.displayName}</span> : note.displayName,
+        label: note.pinned ? (
+          <span className="inline-flex gap-2 items-center">{note.displayName}</span>
+        ) : (
+          note.displayName
+        ),
         icon: <NoteFavicon note={note} />,
         description:
-          note.type === "daily"
-            ? formatDateDistance(note.id)
-            : note.type === "weekly"
-              ? formatWeekDistance(note.id)
-              : note.pinned ? <PinFillIcon12 className="text-text-pinned" /> : null,
-        onSelect: () => { onSelect(note.id); onClose() },
+          note.type === "daily" ? (
+            formatDateDistance(note.id)
+          ) : note.type === "weekly" ? (
+            formatWeekDistance(note.id)
+          ) : note.pinned ? (
+            <PinFillIcon12 className="text-text-pinned" />
+          ) : null,
+        onSelect: () => {
+          onSelect(note.id)
+          onClose()
+        },
       })
     }
 
@@ -95,7 +110,10 @@ export function NotePicker({
         value: "__create__",
         label: `Create new note "${deferredQuery}"`,
         icon: <ComposeIcon16 />,
-        onSelect: () => { onCreateNote(deferredQuery); onClose() },
+        onSelect: () => {
+          onCreateNote(deferredQuery)
+          onClose()
+        },
       })
     }
 
@@ -117,6 +135,7 @@ export function NotePicker({
         placeholder={placeholder}
         value={query}
         onValueChange={setQuery}
+        // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus
         className={cx(
           "placeholder:text-text-tertiary w-full outline-none border-b border-border-secondary",

--- a/src/routes/_appRoot.notes_.$.tsx
+++ b/src/routes/_appRoot.notes_.$.tsx
@@ -508,31 +508,9 @@ function NotePage() {
   return (
     <PageLayout
       title={
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
           <span className="truncate">{noteId}.md</span>
-          {isDraft ? (
-            <DropdownMenu modal={false}>
-              <DropdownMenu.Trigger
-                render={
-                  <IconButton aria-label="Unsaved changes" size="small" className="px-1">
-                    <DraftIndicator />
-                  </IconButton>
-                }
-              />
-              <DropdownMenu.Content>
-                <DropdownMenu.Item
-                  icon={<UndoIcon16 />}
-                  variant="danger"
-                  onClick={() => {
-                    discardChanges()
-                    editorRef.current?.view?.focus()
-                  }}
-                >
-                  Discard changes
-                </DropdownMenu.Item>
-              </DropdownMenu.Content>
-            </DropdownMenu>
-          ) : null}
+          {isDraft ? <DraftIndicator /> : null}
         </div>
       }
       icon={<NoteFavicon note={parsedNote} />}
@@ -630,6 +608,20 @@ function NotePage() {
                 }
               />
               <DropdownMenu.Content align="end">
+                {isDraft ? (
+                  <>
+                    <DropdownMenu.Item
+                      icon={<UndoIcon16 />}
+                      onClick={() => {
+                        discardChanges()
+                        editorRef.current?.view?.focus()
+                      }}
+                    >
+                      Discard changes
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator />
+                  </>
+                ) : null}
                 {containerWidth > 800 && (
                   <>
                     <DropdownMenu.Group>

--- a/src/routes/ai.tsx
+++ b/src/routes/ai.tsx
@@ -96,7 +96,7 @@ function Chat() {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Ask AI…"
-          className="px-4 py-2 bg-bg-secondary w-full leading-7 placeholder:text-text-tertiary focus-ring rounded-xl"
+          className="px-4 py-2 card-1 w-full leading-7 placeholder:text-text-tertiary focus-ring rounded-xl"
         />
       </form>
     </div>

--- a/src/styles/command-menu.css
+++ b/src/styles/command-menu.css
@@ -1,3 +1,4 @@
+/* Command Menu Styles - scoped to command menu component */
 [cmdk-overlay] {
   @apply fixed inset-0 z-20;
 }
@@ -6,37 +7,37 @@
   @apply fixed left-1/2 top-3 z-20 w-[calc(100vw-24px)] max-w-2xl -translate-x-1/2 sm:top-[10vh];
 }
 
-[cmdk-input] {
+[cmdk-dialog] [cmdk-input] {
   @apply w-full bg-transparent px-5 py-4 text-lg leading-none outline-hidden;
 }
 
-[cmdk-input]::placeholder {
+[cmdk-dialog] [cmdk-input]::placeholder {
   @apply text-text-tertiary;
 }
 
-[cmdk-list] {
+[cmdk-dialog] [cmdk-list] {
   @apply max-h-[min(400px,42vh)] overflow-y-auto overflow-x-hidden;
   scroll-padding-block-start: 8px;
   scroll-padding-block-end: 8px;
 }
 
-[cmdk-list]:has([cmdk-list-sizer]:not(:empty)) {
+[cmdk-dialog] [cmdk-list]:has([cmdk-list-sizer]:not(:empty)) {
   @apply border-t border-border-secondary p-2;
 }
 
-[cmdk-group-heading] {
+[cmdk-dialog] [cmdk-group-heading] {
   @apply flex h-8 items-center px-3 text-sm text-text-secondary;
 }
 
-[cmdk-group]:not(:first-child) {
+[cmdk-dialog] [cmdk-group]:not(:first-child) {
   @apply mt-2;
 }
 
-[cmdk-item] {
+[cmdk-dialog] [cmdk-item] {
   @apply cursor-default rounded px-3 py-3 leading-4;
 }
 
-[cmdk-item][aria-selected] {
+[cmdk-dialog] [cmdk-item][aria-selected] {
   @apply bg-bg-secondary;
   @apply epaper:bg-text epaper:text-bg epaper:[&_svg]:text-bg;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,7 +4,7 @@
 @import "./variables.css";
 @import "./markdown.css";
 @import "./codemirror.css";
-@import "./cmdk.css";
+@import "./command-menu.css";
 @import "./prism.css";
 
 @import "tailwindcss";

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -56,7 +56,6 @@
 
 .markdown h1 {
   font-size: var(--font-size-xl);
-  letter-spacing: -0.01em;
 }
 
 .markdown h2 {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -121,7 +121,7 @@
   --font-weight-bold: 600;
 
   /* Border radii */
-  --border-radius-base: 7px;
+  --border-radius-base: 8px;
   --border-radius-sm: calc(var(--border-radius-base) - 4px);
   --border-radius-lg: calc(var(--border-radius-base) + 4px);
   --border-radius-xl: calc(var(--border-radius-base) + 8px);


### PR DESCRIPTION
## Summary

- Replace the date-only "Move to" dropdown on tasks with a searchable note picker that supports moving tasks to any note or creating a new note from the task
- Two UI variants: popover for desktop (inline "Move to" button), dialog for mobile (via overflow menu)
- Scope cmdk CSS selectors to `[cmdk-dialog]` to avoid style conflicts with the new note picker
- Move draft indicator from note title bar into the overflow menu
- Bump `@base-ui/react` from 1.1.0 to 1.2.0
- Misc styling: use container queries for note page padding, update border radius to 8px, tweak dropdown max-height

## Test plan

- [ ] Move a task to an existing note via the inline "Move to" button (desktop)
- [ ] Move a task via the "Move to" option in the overflow menu (mobile)
- [ ] Create a new note from the move picker by typing a name that doesn't match
- [ ] Verify command menu (⌘K) still works correctly with scoped cmdk styles
- [ ] Verify draft indicator appears in overflow menu on unsaved notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)